### PR TITLE
Always use xattrs when calculating file hashes

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -793,7 +793,8 @@ bool compute_hash_with_xattrs(const char *filename)
 		return true;
 	}
 
-	return false;
+	/* Currently swupd-client includes xattrs to hash sums of all files */
+	return true;
 }
 
 /* Returns 0 == success, -1 == failure */


### PR DESCRIPTION
Currently swupd-client includes xattrs to hash sums of all files.
Therefore in order to avoid relaxing security and to prevent
`swupd verify` from reporting hash mismatches for updated files
it's better to include xattrs to hashes for all files.

Signed-off-by: Dmitry Rozhkov dmitry.rozhkov@linux.intel.com
