### PR TITLE
Fix manifest subtraction logic

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -546,15 +546,12 @@ void subtract_manifests(struct manifest *m1, struct manifest *m2)
 			if (file1->is_deleted == file2->is_deleted && file1->is_file == file2->is_file) {
 				m1->files = g_list_delete_link(m1->files, todel);
 				m1->count--;
-				continue;
 			}
-		}
-
-		if (ret < 0) {
+		} else if (ret < 0) {
 			list1 = g_list_next(list1);
-			continue;
+		} else {
+			list2 = g_list_next(list2);
 		}
-		list2 = g_list_next(list2);
 	}
 }
 


### PR DESCRIPTION
In subtract_manifests(), if the two files under consideration have the
same filename but should not be subtracted, a file is skipped in the m2
manifest because there is no "continue" statement at the end of the
first "if" block.

This results in potentially many files not getting subtracted when they
ought to be.

To clarify the logic, avoid using "continue", since it is not needed.
Convert to using one "if" block instead.

Signed-off-by: Patrick McCarty patrick.mccarty@intel.com
