### PR TITLE
Capture logs for every binary

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -222,7 +222,7 @@ extern void populate_file_struct(struct file *file, char *filename);
 extern void download_exta_base_content(void);
 
 extern char *get_elapsed_time(struct timeval *t1, struct timeval *t2);
-extern void init_log(int version);
+extern void init_log(const char *prefix, const char *bundle, int start, int end);
 extern void init_log_stdout(void);
 extern void close_log(int version, int exit_status);
 extern void __log_message(struct file *file, char *msg, char *filename, int linenr, const char *fmt, ...);

--- a/src/log.c
+++ b/src/log.c
@@ -38,11 +38,12 @@ static FILE *logfile;
 
 static struct timeval start_time;
 
-void init_log(int version)
+void init_log(const char *prefix, const char *bundle, int start, int end)
 {
-	char filename[4096];
-	sprintf(filename, "swupd-server.log.%i", version);
+	char *filename;
+	string_or_die(&filename, "%s%s-from-%i-to-%i.log", prefix, bundle, start, end);
 	logfile = fopen(filename, "w");
+	free(filename);
 	gettimeofday(&start_time, NULL);
 }
 void init_log_stdout(void)

--- a/src/main.c
+++ b/src/main.c
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
 	populate_dirs(newversion);
 
 	printf("Next version is %i \n", newversion);
-	init_log(newversion);
+	init_log("swupd-create-update", "", current_version, newversion);
 
 	gettimeofday(&previous_time, NULL);
 

--- a/src/make_fullfiles.c
+++ b/src/make_fullfiles.c
@@ -113,6 +113,8 @@ int main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
+	init_log("swupd-make-fullfiles", "", 0, version);
+
 	manifest = manifest_from_file(version, "full");
 	create_fullfiles(manifest);
 

--- a/src/make_packs.c
+++ b/src/make_packs.c
@@ -116,10 +116,6 @@ int main(int argc, char **argv)
 	banner();
 	check_root();
 
-	/* FIXME: should use "end_version" not "0" and a unique filename
-	init_log(0);
-	*/
-
 	/* Initilize the crypto signature module */
 	if (!signature_initialize()) {
 		printf("Can't initialize the crypto signature module!\n");
@@ -140,6 +136,8 @@ int main(int argc, char **argv)
 		printf("Invalid version combination: %i - %li \n", start_version, end_version);
 		exit(EXIT_FAILURE);
 	}
+
+	init_log("swupd-make-pack-", module, start_version, end_version);
 
 	printf("Making pack-%s %i to %li\n", module, start_version, end_version);
 


### PR DESCRIPTION
To capture all information that is logged, change init_log() to make
every log file name unique, and add a call to swupd_make_fullfiles to
enable logging.

Signed-off-by: Patrick McCarty patrick.mccarty@intel.com
