### PR TITLE
Format handling improvements

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -61,6 +61,7 @@
 #endif
 
 struct manifest {
+	int format;
 	int version;
 	int prevversion;
 	char *component;
@@ -136,7 +137,7 @@ struct packdata {
 extern int current_version;
 extern int newversion;
 extern int minversion;
-extern char *format_string;
+extern int format;
 extern bool enable_signing;
 
 extern char *state_dir;
@@ -146,7 +147,7 @@ extern char *staging_dir;
 
 extern bool init_globals(void);
 extern void free_globals(void);
-extern bool set_format_string(char *);
+extern bool set_format(char *);
 extern void check_root(void);
 extern bool set_state_dir(char *);
 extern bool init_state_globals(void);

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -13,7 +13,6 @@
 // SWUPD_NUM_PACKS is also "PREV_CHECK" in releas tool swupd_bb.py (change both)
 #define SWUPD_NUM_PACKS 4
 #define SWUPD_NUM_MANIFEST_DELTAS 25
-#define SWUPD_DEFAULT_FORMAT 3
 
 #define SWUPD_SERVER_STATE_DIR "/var/lib/update"
 

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -60,7 +60,7 @@
 #endif
 
 struct manifest {
-	int format;
+	unsigned long long int format;
 	int version;
 	int prevversion;
 	char *component;
@@ -136,7 +136,7 @@ struct packdata {
 extern int current_version;
 extern int newversion;
 extern int minversion;
-extern int format;
+extern unsigned long long int format;
 extern bool enable_signing;
 
 extern char *state_dir;

--- a/src/globals.c
+++ b/src/globals.c
@@ -79,7 +79,8 @@ bool set_state_dir(char *dir)
 bool init_globals(void)
 {
 	if (format == -1) {
-		format = SWUPD_DEFAULT_FORMAT;
+		printf("Error: Missing format parameter. Please specify a format with -F.\n");
+		return false;
 	}
 
 	if (!init_state_globals()) {

--- a/src/globals.c
+++ b/src/globals.c
@@ -33,7 +33,7 @@
 
 int newversion = -1;
 int minversion = 0;
-int format = -1;
+unsigned long long int format = 0;
 bool enable_signing = false;
 
 char *state_dir = NULL;
@@ -43,12 +43,12 @@ char *staging_dir = NULL;
 
 bool set_format(char *userinput)
 {
-	int user_format;
+	unsigned long long int user_format;
 
 	// format string shall be a positive integer
 	errno = 0;
 	user_format = strtoull(userinput, NULL, 10);
-	if ((errno < 0) || (user_format <= 0)) {
+	if ((errno < 0) || (user_format == 0)) {
 		return false;
 	}
 	format = user_format;
@@ -78,7 +78,7 @@ bool set_state_dir(char *dir)
 
 bool init_globals(void)
 {
-	if (format == -1) {
+	if (format == 0) {
 		printf("Error: Missing format parameter. Please specify a format with -F.\n");
 		return false;
 	}

--- a/src/globals.c
+++ b/src/globals.c
@@ -33,7 +33,7 @@
 
 int newversion = -1;
 int minversion = 0;
-char *format_string = NULL;
+int format = -1;
 bool enable_signing = false;
 
 char *state_dir = NULL;
@@ -41,20 +41,17 @@ char *packstage_dir = NULL;
 char *image_dir = NULL;
 char *staging_dir = NULL;
 
-bool set_format_string(char *userinput)
+bool set_format(char *userinput)
 {
-	int version;
+	int user_format;
 
-	// expect a positive integer
+	// format string shall be a positive integer
 	errno = 0;
-	version = strtoull(userinput, NULL, 10);
-	if ((errno < 0) || (version <= 0)) {
+	user_format = strtoull(userinput, NULL, 10);
+	if ((errno < 0) || (user_format <= 0)) {
 		return false;
 	}
-	if (format_string) {
-		free(format_string);
-	}
-	string_or_die(&format_string, "%d", version);
+	format = user_format;
 
 	return true;
 }
@@ -81,8 +78,8 @@ bool set_state_dir(char *dir)
 
 bool init_globals(void)
 {
-	if (format_string == NULL) {
-		string_or_die(&format_string, "%d", SWUPD_DEFAULT_FORMAT);
+	if (format == -1) {
+		format = SWUPD_DEFAULT_FORMAT;
 	}
 
 	if (!init_state_globals()) {
@@ -101,7 +98,6 @@ bool init_globals(void)
 
 void free_globals(void)
 {
-	free(format_string);
 	free(state_dir);
 	free(packstage_dir);
 	free(image_dir);

--- a/src/main.c
+++ b/src/main.c
@@ -69,7 +69,7 @@ static void print_help(const char *name)
 	printf("Application Options:\n");
 	printf("   -o, --osversion         The OS version for which to create an update\n");
 	printf("   -m, --minversion        Optional minimum file version to write into manifests per file\n");
-	printf("   -F, --format            Optional format string [ default:=%d ]\n", SWUPD_DEFAULT_FORMAT);
+	printf("   -F, --format            Format number for the update\n");
 	printf("   -g, --getformat         Print current format string and exit\n");
 	printf("   -S, --statedir          Optional directory to use for state [ default:=%s ]\n", SWUPD_SERVER_STATE_DIR);
 	printf("   -s, --signcontent       Enables cryptographic signing of update content\n");
@@ -118,7 +118,7 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'g':
 			if (format == -1) {
-				printf("%d\n", SWUPD_DEFAULT_FORMAT);
+				printf("No format specified\n");
 			} else {
 				printf("%d\n", format);
 				free_globals();

--- a/src/main.c
+++ b/src/main.c
@@ -117,10 +117,10 @@ static bool parse_options(int argc, char **argv)
 			}
 			break;
 		case 'g':
-			if (format == -1) {
+			if (format == 0) {
 				printf("No format specified\n");
 			} else {
-				printf("%d\n", format);
+				printf("%llu\n", format);
 				free_globals();
 			}
 			exit(0);

--- a/src/main.c
+++ b/src/main.c
@@ -105,7 +105,7 @@ static bool parse_options(int argc, char **argv)
 			}
 			break;
 		case 'F':
-			if (!optarg || !set_format_string(optarg)) {
+			if (!optarg || !set_format(optarg)) {
 				printf("Invalid --format argument\n\n");
 				return false;
 			}
@@ -117,10 +117,10 @@ static bool parse_options(int argc, char **argv)
 			}
 			break;
 		case 'g':
-			if (format_string == NULL) {
+			if (format == -1) {
 				printf("%d\n", SWUPD_DEFAULT_FORMAT);
 			} else {
-				printf("%s\n", format_string);
+				printf("%d\n", format);
 				free_globals();
 			}
 			exit(0);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -769,7 +769,7 @@ static int write_manifest_plain(struct manifest *manifest)
 		goto exit;
 	}
 
-	fprintf(out, "MANIFEST\t%d\n", format);
+	fprintf(out, "MANIFEST\t%llu\n", format);
 	fprintf(out, "version:\t%i\n", manifest->version);
 	fprintf(out, "previous:\t%i\n", manifest->prevversion);
 	fprintf(out, "filecount:\t%i\n", manifest->count);

--- a/src/versions.c
+++ b/src/versions.c
@@ -139,7 +139,7 @@ void write_cookiecrumbs_to_download_area(int version)
 	}
 	free(cmd);
 
-	string_or_die(&cmd, "echo %s > %s/%i/format", format_string, conf, version);
+	string_or_die(&cmd, "echo %d > %s/%i/format", format, conf, version);
 	if (system(cmd) != 0) {
 		assert(0);
 	}


### PR DESCRIPTION
Over time, manifests accumulate lots of deleted files which bloat the manifest. At the time of a format increment, the deleted file entries in manifests prior to the current version can be pruned; the first patch implements this change.

Also, remove the hardcoding of the format "3" in the swupd_create_update binary. Instead, always require the -F option. In the future, I imagine that the default value could be read from a config file, and -F would override, but for now just require -F.
