### PR TITLE
Fix manifests not detecting include changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -110,6 +110,7 @@ TESTS = $(dist_check_SCRIPTS)
 dist_check_SCRIPTS = \
 	test/functional/basic.bats \
 	test/functional/delete-no-version-bump.bats \
+	test/functional/include-version-bump.bats \
 	test/functional/update.bats \
 	test/functional/fullfiles.bats \
 	test/functional/pack.bats \

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -175,6 +175,8 @@ extern void free_manifest(struct manifest *manifest);
 extern struct manifest *alloc_manifest(int version, char *module);
 extern int match_manifests(struct manifest *m1, struct manifest *m2);
 extern void sort_manifest_by_version(struct manifest *manifest);
+extern bool manifest_includes(struct manifest *manifest, char *component);
+extern bool changed_includes(struct manifest *old, struct manifest *new);
 extern int prune_manifest(struct manifest *manifest);
 extern void create_manifest_delta(int oldversion, int newversion, char *module);
 extern void create_manifest_deltas(struct manifest *manifest, GList *last_versions_list);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -877,6 +877,44 @@ void sort_manifest_by_version(struct manifest *manifest)
 	}
 }
 
+bool manifest_includes(struct manifest *manifest, char *component)
+{
+        GList *includes = g_list_first(manifest->includes);
+
+        while (includes) {
+                if (strcmp(((struct manifest *)includes->data)->component,
+                           component) == 0) {
+                        return true;
+                }
+                includes = g_list_next(includes);
+        }
+
+        return false;
+}
+
+bool changed_includes(struct manifest *old, struct manifest *new)
+{
+        GList *includes_old = g_list_first(old->includes);
+        GList *includes_new = g_list_first(new->includes);
+
+        if (g_list_length(includes_old) != g_list_length(includes_new)) {
+                return true;
+        }
+
+        while (includes_old && includes_new) {
+                char *bundle_old = ((struct manifest *)includes_old->data)->component;
+                char *bundle_new = ((struct manifest *)includes_new->data)->component;
+                if (strcmp(bundle_old, bundle_new) != 0) {
+                        return true;
+                }
+
+                includes_old = g_list_next(includes_old);
+                includes_new = g_list_next(includes_new);
+        }
+
+        return false;
+}
+
 /* Conditionally remove some things from a manifest.
  * Returns > 0 when the pruned manifest has new files.
  * Returns 0 when the pruned manifest no longer has new files.

--- a/test/functional/include-version-bump.bats
+++ b/test/functional/include-version-bump.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+# common functions
+load swupdlib
+
+setup() {
+  DIR=$(init_web_dir "$srcdir/web-dir")
+  export DIR
+
+  init_server_ini
+  set_latest_ver 0
+  init_groups_ini os-core test-bundle included included-two included-nested
+
+  set_os_release 10 os-core
+  track_bundle 10 os-core
+  track_bundle 10 test-bundle
+
+  set_os_release 20 os-core
+  track_bundle 20 os-core
+  track_bundle 20 test-bundle
+  track_bundle 20 included
+  track_bundle 20 included-two
+
+  set_os_release 30 os-core
+  track_bundle 30 os-core
+  track_bundle 30 test-bundle
+  track_bundle 30 included
+  track_bundle 30 included-two
+  track_bundle 30 included-nested
+
+  gen_file_plain 10 test-bundle foo
+  gen_file_plain 20 test-bundle foo
+  gen_file_plain 20 included bar
+  gen_file_plain 20 included-two baz
+  gen_file_plain 30 test-bundle foo
+  gen_file_plain 30 included bar
+  gen_file_plain 30 included-two baz
+  gen_file_plain 30 included-nested foobarbaz
+
+  gen_includes_file test-bundle 20 included included-two
+  gen_includes_file test-bundle 30 included included-two
+  gen_includes_file included 30 included-nested
+}
+
+@test "full run update creation with delta packs" {
+  # build the first version
+  sudo $srcdir/swupd_create_update --osversion 10 --statedir $DIR
+  sudo $srcdir/swupd_make_fullfiles --statedir $DIR 10
+  sudo $srcdir/swupd_make_pack --statedir $DIR 0 10 os-core
+  sudo $srcdir/swupd_make_pack --statedir $DIR 0 10 test-bundle
+
+  set_latest_ver 10
+
+  # then the second version...
+  sudo $srcdir/swupd_create_update --osversion 20 --statedir $DIR
+  sudo $srcdir/swupd_make_fullfiles --statedir $DIR 20
+  sudo $srcdir/swupd_make_pack --statedir $DIR 0 20 os-core
+  sudo $srcdir/swupd_make_pack --statedir $DIR 0 20 test-bundle
+  sudo $srcdir/swupd_make_pack --statedir $DIR 0 20 included
+  sudo $srcdir/swupd_make_pack --statedir $DIR 0 20 included-two
+
+  set_latest_ver 20
+
+  # then the third version...
+  sudo $srcdir/swupd_create_update --osversion 30 --statedir $DIR
+  sudo $srcdir/swupd_make_fullfiles --statedir $DIR 30
+  sudo $srcdir/swupd_make_pack --statedir $DIR 0 30 os-core
+  sudo $srcdir/swupd_make_pack --statedir $DIR 0 30 test-bundle
+  sudo $srcdir/swupd_make_pack --statedir $DIR 0 30 included
+  sudo $srcdir/swupd_make_pack --statedir $DIR 0 30 included-two
+  sudo $srcdir/swupd_make_pack --statedir $DIR 0 30 included-nested
+
+  # zero packs should exist (non-zero size) for both versions
+  [ -s $DIR/www/10/pack-os-core-from-0.tar ]
+  [ -s $DIR/www/10/pack-test-bundle-from-0.tar ]
+  [ -s $DIR/www/20/pack-os-core-from-0.tar ]
+  [ -s $DIR/www/20/pack-test-bundle-from-0.tar ]
+  [ -s $DIR/www/20/pack-included-from-0.tar ]
+  [ -s $DIR/www/20/pack-included-two-from-0.tar ]
+  [ -s $DIR/www/30/pack-os-core-from-0.tar ]
+  [ -s $DIR/www/30/pack-test-bundle-from-0.tar ]
+  [ -s $DIR/www/30/pack-included-from-0.tar ]
+  [ -s $DIR/www/30/pack-included-two-from-0.tar ]
+  [ -s $DIR/www/30/pack-included-nested-from-0.tar ]
+
+  [[ 1 -eq $(grep '^includes:	os-core$' $DIR/www/10/Manifest.test-bundle | wc -l) ]]
+  [[ 1 -eq $(grep '/foo$' $DIR/www/10/Manifest.test-bundle | wc -l) ]]
+  [[ 1 -eq $(grep '^includes:	os-core$' $DIR/www/20/Manifest.test-bundle | wc -l) ]]
+  [[ 1 -eq $(grep '^includes:	included$' $DIR/www/20/Manifest.test-bundle | wc -l) ]]
+  [[ 1 -eq $(grep '^includes:	included-two$' $DIR/www/20/Manifest.test-bundle | wc -l) ]]
+  [[ 1 -eq $(grep '/bar$' $DIR/www/20/Manifest.included | wc -l) ]]
+  [[ 1 -eq $(grep '/baz$' $DIR/www/20/Manifest.included-two | wc -l) ]]
+  [[ 1 -eq $(grep '^includes:	included-nested$' $DIR/www/30/Manifest.included | wc -l) ]]
+  [[ 1 -eq $(grep '/foobarbaz$' $DIR/www/30/Manifest.included-nested | wc -l) ]]
+  [[ 0 -eq $(ls $DIR/www/30/Manifest.test-bundle | wc -l) ]]
+  [[ 0 -eq $(ls $DIR/www/30/Manifest.included-two | wc -l) ]]
+}
+
+teardown() {
+  sudo rm -rf $DIR
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
When deciding if a new manifest should be generated for a new version,
the included manifests were not being used to detect a manifest
change. This caused manifests that had new includes: lines in the new
version to not be generated resulting in files from the included
manifest to be missed when adding/updating that bundle.

The fix was to compare includes: lines from the current and previous
manifest versions for differences and generate new manifests when that
was the case. In order to compare manifests duplicate includes: lines
are not allowed and previously os-core could be added multiple times to
a manifest because it was always added. This change also added detection
for os-core before automatically adding it to a bundle.
