### PR TITLE
Change delta's name from FROM-TO-HASH2 to FROM-TO-HASH1-HASH2 format.

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -238,7 +238,7 @@ extern void type_change_detection(struct manifest *manifest);
 
 extern void rename_detection(struct manifest *manifest, int last_change, GList *last_versions_list);
 extern void link_renames(GList *newfiles, struct manifest *from_manifest);
-extern void __create_delta(struct file *file, int from_version);
+extern void __create_delta(struct file *file, int from_version, char *from_hash);
 
 extern void account_delta_hit(void);
 extern void account_delta_miss(void);

--- a/src/delta.c
+++ b/src/delta.c
@@ -35,7 +35,7 @@
 #include "swupd.h"
 #include "xattrs.h"
 
-void __create_delta(struct file *file, int from_version)
+void __create_delta(struct file *file, int from_version, char *from_hash)
 {
 	char *original, *newfile, *outfile, *dotfile, *testnewfile, *sanitycheck;
 	char *conf;
@@ -62,9 +62,9 @@ void __create_delta(struct file *file, int from_version)
 
 	conf = config_output_dir();
 
-	string_or_die(&outfile, "%s/%i/delta/%i-%i-%s", conf, file->last_change, from_version, file->last_change, file->hash);
-	string_or_die(&dotfile, "%s/%i/delta/.%i-%i-%s", conf, file->last_change, from_version, file->last_change, file->hash);
-	string_or_die(&testnewfile, "%s/%i/delta/.%i-%i-%s.testnewfile", conf, file->last_change, from_version, file->last_change, file->hash);
+	string_or_die(&outfile, "%s/%i/delta/%i-%i-%s-%s", conf, file->last_change, from_version, file->last_change, from_hash, file->hash);
+	string_or_die(&dotfile, "%s/%i/delta/.%i-%i-%s-%s", conf, file->last_change, from_version, file->last_change, from_hash, file->hash);
+	string_or_die(&testnewfile, "%s/%i/delta/.%i-%i-%s-%s.testnewfile", conf, file->last_change, from_version, file->last_change, from_hash, file->hash);
 	string_or_die(&sanitycheck, "cmp -s \"%s\" \"%s\"", newfile, testnewfile);
 
 	LOG(file, "Making delta", "%s->%s", original, newfile);

--- a/src/pack.c
+++ b/src/pack.c
@@ -257,8 +257,8 @@ static GList *consolidate_packs_delta_files(GList *files, struct packdata *pack)
 			continue;
 		}
 
-		string_or_die(&from, "%s/%i/delta/%i-%i-%s", staging_dir, file->last_change,
-			      file->peer->last_change, file->last_change, file->hash);
+		string_or_die(&from, "%s/%i/delta/%i-%i-%s-%s", staging_dir, file->last_change,
+			      file->peer->last_change, file->last_change, file->peer->hash, file->hash);
 
 		ret = stat(from, &stat_delta);
 		if (ret && !find_file_in_list(files, file)) {
@@ -277,7 +277,7 @@ static void create_delta(gpointer data, __unused__ gpointer user_data)
 
 	/* if the file was not found in the from version, skip delta creation */
 	if (file->peer) {
-		__create_delta(file, file->peer->last_change);
+		__create_delta(file, file->peer->last_change, file->peer->hash);
 	}
 }
 
@@ -356,11 +356,11 @@ static int make_final_pack(struct packdata *pack)
 
 		/* for each file changed since <X> */
 		/* locate delta, check if the diff it's from is >= <X> */
-		string_or_die(&from, "%s/%i/delta/%i-%i-%s", staging_dir, file->last_change,
-			      file->peer->last_change, file->last_change, file->hash);
-		string_or_die(&to, "%s/%s/%i_to_%i/delta/%i-%i-%s", packstage_dir,
+		string_or_die(&from, "%s/%i/delta/%i-%i-%s-%s", staging_dir, file->last_change,
+			      file->peer->last_change, file->last_change, file->peer->hash, file->hash);
+		string_or_die(&to, "%s/%s/%i_to_%i/delta/%i-%i-%s-%s", packstage_dir,
 			      pack->module, pack->from, pack->to, file->peer->last_change,
-			      file->last_change, file->hash);
+			      file->last_change, file->peer->hash, file->hash);
 		string_or_die(&tarfrom, "%s/%i/files/%s.tar", staging_dir,
 			      file->last_change, file->hash);
 		string_or_die(&tarto, "%s/%s/%i_to_%i/staged/%s.tar", packstage_dir,


### PR DESCRIPTION
There is an issue when two different files in a newer release have same hash:
This is, when swupd updates a file by applying a delta, it takes the HASH2 to
know the file where delta must be applyed. If files are different in current
release (before updating), there must be 2 deltas, one for each file but as
the two files have same hash in new release delta's name are the same:
FROM-TO-HASH2 and it is when issue arises due to just the last delta file is
kept when swupd server creates files and packs. So when swupd client tries to
apply the delta to one of the file that does not corresponds it will fail and
generates an error. At the first look it will seem like delta file is corrupted
however the issue is that delta file was created for another file.
To solve this issue we include the hash for the original file in the delta's
name so that swupd client can take the correct delta and apply it:
FROM-TO-HASH1-HASH2.

Warning: A corresponding patch to swupd client must be applied in order to
sync both sides and understand the new delta's name format.

->
Refer to https://github.com/jrguzman-intel/swupd-client/commit/49175ce96aae78515d70a6cd6e7aed1291247f98
-<

Signed-off-by: Jose R Guzman jose.r.guzman.mosqueda@intel.com
