### PR TITLE
[clearlinux/swupd-server] Replace system calls by local system_argv functions.

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -252,7 +252,7 @@ extern void dump_file_info(struct file *file);
 extern void string_or_die(char **strp, const char *fmt, ...);
 extern void print_elapsed_time(const char *step, struct timeval *previous_time, struct timeval *current_time);
 extern int system_argv(char *const argv[]);
-extern int system_argv_fd(char *const argv[], int stdin, int stdout, int stderr);
+extern int system_argv_fd(char *const argv[], int newstdin, int newstdout, int newstderr);
 extern int system_argv_pipe(char *const argvp1[], int stdinp1, int stderrp1,
 							char *const argvp2[], int stdoutp2, int stderrp2);
 

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -19,17 +19,21 @@
 #if SWUPD_WITH_BSDTAR
 #define TAR_COMMAND "bsdtar"
 #define TAR_XATTR_ARGS ""
+#define TAR_XATTR_ARGS_STRLIST
 #define TAR_WARN_ARGS ""
 #else
 #define TAR_COMMAND "tar"
 #define TAR_XATTR_ARGS "--xattrs --xattrs-include='*'"
+#define TAR_XATTR_ARGS_STRLIST "--xattrs", "--xattrs-include='*'",
 #define TAR_WARN_ARGS "--warning=no-timestamp"
 #endif
 
 #if SWUPD_WITH_SELINUX
 #define TAR_PERM_ATTR_ARGS "--preserve-permissions --selinux " TAR_XATTR_ARGS
+#define TAR_PERM_ATTR_ARGS_STRLIST TAR_XATTR_ARGS_STRLIST "--preserve-permissions", "--selinux"
 #else
 #define TAR_PERM_ATTR_ARGS "--preserve-permissions " TAR_XATTR_ARGS
+#define TAR_PERM_ATTR_ARGS_STRLIST TAR_XATTR_ARGS_STRLIST "--preserve-permissions"
 #endif
 
 #if SWUPD_WITH_STATELESS
@@ -248,6 +252,9 @@ extern void dump_file_info(struct file *file);
 extern void string_or_die(char **strp, const char *fmt, ...);
 extern void print_elapsed_time(const char *step, struct timeval *previous_time, struct timeval *current_time);
 extern int system_argv(char *const argv[]);
+extern int system_argv_fd(char *const argv[], int stdin, int stdout, int stderr);
+extern int system_argv_pipe(char *const argvp1[], int stdinp1, int stderrp1,
+							char *const argvp2[], int stdoutp2, int stderrp2);
 
 extern bool signature_initialize(void);
 extern void signature_terminate(void);

--- a/src/chroot.c
+++ b/src/chroot.c
@@ -34,9 +34,8 @@
 
 void chroot_create_full(int newversion)
 {
-	int ret;
 	char *group;
-	char *command;
+	char *param;
 	char *full_dir;
 
 	string_or_die(&full_dir, "%s/%i/full/", image_dir, newversion);
@@ -45,11 +44,12 @@ void chroot_create_full(int newversion)
 
 	/* start with base */
 	LOG(NULL, "Copying chroot os-core to full", "");
-	string_or_die(&command, "rsync -aAX %s/%i/os-core/ %s",
-		      image_dir, newversion, full_dir);
-	ret = system(command);
-	assert(ret == 0);
-	free(command);
+	string_or_die(&param, "%s/%i/os-core/", image_dir, newversion);
+	char *const rsynccmd[] = { "rsync", "-aAX", param, full_dir, NULL };
+	if (system_argv(rsynccmd) != 0) {
+		assert(0);
+	}
+	free(param);
 
 	/* overlay any new files from each group */
 	while (1) {
@@ -59,11 +59,12 @@ void chroot_create_full(int newversion)
 		}
 
 		LOG(NULL, "Overlaying bundle chroot onto full", "%s", group);
-		string_or_die(&command, "rsync -aAX --ignore-existing %s/%i/%s/ %s",
-			      image_dir, newversion, group, full_dir);
-		ret = system(command);
-		assert(ret == 0);
-		free(command);
+		string_or_die(&param, "%s/%i/%s/", image_dir, newversion, group);
+		char *const rsynccmd[] = { "rsync", "-aAX", "--ignore-existing", param, full_dir, NULL };
+		if (system_argv(rsynccmd) != 0) {
+			assert(0);
+		}
+		free(param);
 	}
 	free(full_dir);
 }

--- a/src/delta.c
+++ b/src/delta.c
@@ -115,12 +115,12 @@ void __create_delta(struct file *file, int from_version)
 	ret = system_argv(sanitycheck);
 	free(param1);
 	free(param2);
-	if (ret == -1 || !WIFEXITED(ret) || WEXITSTATUS(ret) == 2) {
+	if (ret == -1 || ret == 2) {
 		printf("Sanity check system command failed %i. \n", ret);
 		printf("%s->%s via diff %s yielded %s\n", original, newfile, dotfile, testnewfile);
 		assert(0);
 		goto out;
-	} else if (WEXITSTATUS(ret) == 1) {
+	} else if (ret == 1) {
 		printf("Delta application resulted in file mismatch %i. \n", ret);
 		printf("%s->%s via diff %s yielded %s\n", original, newfile, dotfile, testnewfile);
 		LOG(file, "Delta mismatch:", "%s->%s via diff %s yielded %s", original, newfile, dotfile, testnewfile);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -200,21 +200,21 @@ int system_argv_fd(char *const argv[], int newstdin, int newstdout, int newstder
 	pid = fork();
 
 	if (pid == 0) { /* child */
-		if(newstdin >= 0) {
+		if (newstdin >= 0) {
 			if (dup2(newstdin, STDIN_FILENO) == -1) {
 				LOG(NULL, "Could not redirect stdin", "");
 				assert(0);
 			}
 			close(newstdin);
 		}
-		if(newstdout >= 0) {
+		if (newstdout >= 0) {
 			if (dup2(newstdout, STDOUT_FILENO) == -1) {
 				LOG(NULL, "Could not redirect stdout", "");
 				assert(0);
 			}
 			close(newstdout);
 		}
-		if(newstderr >= 0) {
+		if (newstderr >= 0) {
 			if (dup2(newstderr, STDERR_FILENO) == -1) {
 				LOG(NULL, "Could not redirect stderr", "");
 				assert(0);
@@ -258,21 +258,21 @@ int system_argv_fd(char *const argv[], int newstdin, int newstdout, int newstder
 int system_argv_pipe(char *const argvp1[], int stdinp1, int stderrp1,
 					 char *const argvp2[], int stdoutp2, int stderrp2)
 {
-	int statusp1, statusp2;
+	int statusp2;
 	int pipefd[2];
 
 	if (pipe(pipefd)) {
 		LOG(NULL, "Failed to create a pipe", "");
 		return -1;
 	}
-	statusp1 = system_argv_fd(argvp1, stdinp1, pipefd[1], stderrp1);
+	system_argv_fd(argvp1, stdinp1, pipefd[1], stderrp1);
 	close(pipefd[1]);
 	statusp2 = system_argv_fd(argvp2, pipefd[0], stdoutp2, stderrp2);
 	close(pipefd[0]);
 
 	/* Returns the status of the failed process if any
        If both processes failed returns the status of first one */
-	return statusp1 ? statusp1 : statusp2;
+	return statusp2;
 }
 
 void check_root(void)

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -841,7 +841,7 @@ static int write_manifest_tar(struct manifest *manifest)
 {
 	char *conf = config_output_dir();
 	char *directory, *manifesttar, *manifestcomp, *manifestsigned;
-	int ret = -1;
+	int ret = 0;
 
 	if (conf == NULL) {
 		assert(0);
@@ -867,7 +867,6 @@ static int write_manifest_tar(struct manifest *manifest)
 		fprintf(stderr, "Creation of Manifest.tar failed\n");
 	}
 
-exit:
 	free(directory);
 	free(manifesttar);
 	free(manifestcomp);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -857,20 +857,16 @@ static int write_manifest_tar(struct manifest *manifest)
 	if (enable_signing) {
 		char *const tarcmd[] = { TAR_COMMAND, directory, TAR_PERM_ATTR_ARGS_STRLIST, "-Jcf",
 								 manifesttar, manifestcomp, manifestsigned, NULL};
-		if (system_argv(tarcmd) != 0) {
-			fprintf(stderr, "Creation of Manifest.tar failed\n");
-			goto exit;
-		}
+		ret = system_argv(tarcmd);
 	} else {
 		char *const tarcmd[] = { TAR_COMMAND, directory, TAR_PERM_ATTR_ARGS_STRLIST, "-Jcf",
 								 manifesttar, manifestcomp, NULL};
-		if (system_argv(tarcmd) != 0) {
-			fprintf(stderr, "Creation of Manifest.tar failed\n");
-			goto exit;
-		}
+		ret = system_argv(tarcmd);
+	}
+	if (ret) {
+		fprintf(stderr, "Creation of Manifest.tar failed\n");
 	}
 
-	ret = 0;
 exit:
 	free(directory);
 	free(manifesttar);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -840,34 +840,42 @@ exit:
 static int write_manifest_tar(struct manifest *manifest)
 {
 	char *conf = config_output_dir();
-	char *tarcmd = NULL;
+	char *directory, *manifesttar, *manifestcomp, *manifestsigned;
 	int ret = -1;
 
 	if (conf == NULL) {
 		assert(0);
 	}
 
+	string_or_die(&directory, "--directory=%s/%i",  conf, manifest->version);
+	string_or_die(&manifesttar, "%s/%i/Manifest.%s.tar",  conf, manifest->version, manifest->component);
+	string_or_die(&manifestcomp, "Manifest.%s",  manifest->component);
+	string_or_die(&manifestsigned, "Manifest.%s.signed",  manifest->component);
+
 	/* now, tar the thing up for efficient full file download */
 	/* and put the signature of the plain manifest into the archive, too */
 	if (enable_signing) {
-		string_or_die(&tarcmd, TAR_COMMAND " --directory=%s/%i " TAR_PERM_ATTR_ARGS " -Jcf "
-						   "%s/%i/Manifest.%s.tar Manifest.%s Manifest.%s.signed",
-			      conf, manifest->version, conf, manifest->version, manifest->component,
-			      manifest->component, manifest->component);
+		char *const tarcmd[] = { TAR_COMMAND, directory, TAR_PERM_ATTR_ARGS_STRLIST, "-Jcf",
+								 manifesttar, manifestcomp, manifestsigned, NULL};
+		if (system_argv(tarcmd) != 0) {
+			fprintf(stderr, "Creation of Manifest.tar failed\n");
+			goto exit;
+		}
 	} else {
-		string_or_die(&tarcmd, TAR_COMMAND " --directory=%s/%i " TAR_PERM_ATTR_ARGS " -Jcf "
-						   "%s/%i/Manifest.%s.tar Manifest.%s",
-			      conf, manifest->version, conf, manifest->version, manifest->component,
-			      manifest->component);
+		char *const tarcmd[] = { TAR_COMMAND, directory, TAR_PERM_ATTR_ARGS_STRLIST, "-Jcf",
+								 manifesttar, manifestcomp, NULL};
+		if (system_argv(tarcmd) != 0) {
+			fprintf(stderr, "Creation of Manifest.tar failed\n");
+			goto exit;
+		}
 	}
 
-	if (system(tarcmd) != 0) {
-		fprintf(stderr, "Creation of Manifest.tar failed\n");
-		goto exit;
-	}
 	ret = 0;
 exit:
-	free(tarcmd);
+	free(directory);
+	free(manifesttar);
+	free(manifestcomp);
+	free(manifestsigned);
 	free(conf);
 	return ret;
 }

--- a/src/pack.c
+++ b/src/pack.c
@@ -496,7 +496,7 @@ static int make_final_pack(struct packdata *pack)
 	free(param2);
 	LOG(NULL, "finished tar for pack", "%s: %i to %i", pack->module, pack->from, pack->to);
 	/* FIXME: this is a hack workaround, needs diagnosed and removed */
-	if ((ret != 0) && (ret != 256)) {
+	if ((ret != 0) && (ret != 1)) {
 		fprintf(stderr, "Unexpected return value (%d) creating tar of pack %s from %i to %i\n",
 			ret, pack->module, pack->from, pack->to);
 	} else {

--- a/src/pack.c
+++ b/src/pack.c
@@ -40,21 +40,19 @@
 
 static void empty_pack_stage(int full, int from_version, int to_version, char *module)
 {
-	char *cmd;
+	char *param;
 	char *path;
-	int ret;
 
 	// clean any stale data (eg: re-run after a failure)
-	string_or_die(&cmd, "rm -rf %s/%s/%i_to_%i/", packstage_dir, module,
-		      from_version, to_version);
-	ret = system(cmd);
-	if (ret) {
+	string_or_die(&param, "%s/%s/%i_to_%i/", packstage_dir, module, from_version, to_version);
+	char *const rmcmd[] = { "rm", "-fr", param, NULL };
+	if (system_argv(rmcmd) != 0) {
 		fprintf(stderr, "Failed to clean %s/%s/%i_to_%i\n",
 			packstage_dir, module, from_version, to_version);
-		free(cmd);
+		free(param);
 		exit(EXIT_FAILURE);
 	}
-	free(cmd);
+	free(param);
 
 	if (!full) {
 		// (re)create module/version/{delta,staged}
@@ -89,7 +87,7 @@ static void explode_pack_stage(int from_version, int to_version, char *module)
 	}
 	free(path);
 	while (1) {
-		char *path, *tar;
+		char *path, *param;
 		int ret;
 
 		entry = readdir(dir);
@@ -117,13 +115,12 @@ static void explode_pack_stage(int from_version, int to_version, char *module)
 		 * the resulting pack is slightly smaller, and in addition, we're saving CPU
 		 * time on the client...
 		 */
-		string_or_die(&tar, TAR_COMMAND " --directory=%s/%s/%i_to_%i/staged " TAR_WARN_ARGS " " TAR_PERM_ATTR_ARGS " -xf %s",
-			      packstage_dir, module, from_version, to_version, path);
-		ret = system(tar);
-		if (!ret) {
+		string_or_die(&param, "--directory=%s/%s/%i_to_%i/staged", packstage_dir, module, from_version, to_version);
+		char *const tarcmd[] = { TAR_COMMAND, param, TAR_WARN_ARGS, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", path, NULL };
+		if (system_argv(tarcmd) == 0) {
 			unlink(path);
 		}
-		free(tar);
+		free(param);
 		free(path);
 	}
 	closedir(dir);
@@ -334,7 +331,7 @@ static int make_final_pack(struct packdata *pack)
 	GList *item;
 	struct file *file;
 	int ret;
-	char *tar;
+	char *param1, *param2;
 	double penalty;
 
 	LOG(NULL, "make_final_pack", "%s: %i to %i", pack->module, pack->from, pack->to);
@@ -491,12 +488,12 @@ static int make_final_pack(struct packdata *pack)
 
 	/* tar the staging directory up */
 	LOG(NULL, "starting tar for pack", "%s: %i to %i", pack->module, pack->from, pack->to);
-	string_or_die(&tar, TAR_COMMAND " " TAR_PERM_ATTR_ARGS " --directory=%s/%s/%i_to_%i/ "
-					"--numeric-owner -Jcf %s/%i/pack-%s-from-%i.tar delta staged",
-		      packstage_dir, pack->module, pack->from, pack->to, staging_dir, pack->to,
-		      pack->module, pack->from);
-	ret = system(tar);
-	free(tar);
+	string_or_die(&param1, "--directory=%s/%s/%i_to_%i/", packstage_dir, pack->module, pack->from, pack->to);
+	string_or_die(&param2, "%s/%i/pack-%s-from-%i.tar", staging_dir, pack->to, pack->module, pack->from);
+	char *const tarcmd[] = { TAR_COMMAND, TAR_PERM_ATTR_ARGS_STRLIST, param1, "--numeric-owner", "-Jcf", param2, "delta", "staged", NULL };
+	ret = system_argv(tarcmd);
+	free(param1);
+	free(param2);
 	LOG(NULL, "finished tar for pack", "%s: %i to %i", pack->module, pack->from, pack->to);
 	/* FIXME: this is a hack workaround, needs diagnosed and removed */
 	if ((ret != 0) && (ret != 256)) {

--- a/src/versions.c
+++ b/src/versions.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #include "swupd.h"
 
@@ -126,24 +127,37 @@ void ensure_version_image_exists(int version)
 void write_cookiecrumbs_to_download_area(int version)
 {
 	char *conf;
-	char *cmd;
+	char *filename, *strformat;
+	int versionfd, formatfd;
 
 	conf = config_output_dir();
 	if (conf == NULL) {
 		assert(0);
 	}
 
-	string_or_die(&cmd, "echo %s > %s/%i/swupd-server-src-version", VERSION, conf, version);
-	if (system(cmd) != 0) {
+	string_or_die(&filename, "%s/%i/swupd-server-src-version", conf, version);
+	versionfd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0664);
+	if (versionfd == -1) {
 		assert(0);
 	}
-	free(cmd);
+	if (write(versionfd, VERSION, strlen(VERSION)) != strlen(VERSION)) {
+		assert(0);
+	}
+	close(versionfd);
+	free(filename);
 
-	string_or_die(&cmd, "echo %llu > %s/%i/format", format, conf, version);
-	if (system(cmd) != 0) {
+	string_or_die(&filename, "%s/%i/format", conf, version);
+	string_or_die(&strformat, "%llu", format);
+	formatfd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0664);
+	if (formatfd == -1) {
 		assert(0);
 	}
-	free(cmd);
+	if (write(formatfd, strformat, strlen(strformat)) != (ssize_t)strlen(strformat)) {
+		assert(0);
+	}
+	close(formatfd);
+	free(filename);
+	free(strformat);
 
 /* Updating the WEBDIR/version/formatN/latest file is an operation very closely tied to a DevOps
  * workflow and not something swupd should make a decision about.
@@ -161,12 +175,15 @@ void write_cookiecrumbs_to_download_area(int version)
 #if 0
 	FILE *file;
 	char *fullfile = NULL;
+	char *param;
 
-	string_or_die(&cmd, "mkdir -p %s/version/formatstaging/", conf);
-	if (system(cmd) != 0) {
+	string_or_die($param, "%s/version/formatstaging/", conf);
+	char *const mkdircmd[] = { "mkdir", "-p", param, NULL };
+
+	if (system_argv(mkdircmd) != 0) {
 		assert(0);
 	}
-	free(cmd);
+	free(param);
 
 	string_or_die(&fullfile, "%s/version/formatstaging/latest", conf);
 	file = fopen(fullfile, "w");

--- a/src/versions.c
+++ b/src/versions.c
@@ -128,7 +128,7 @@ void write_cookiecrumbs_to_download_area(int version)
 {
 	char *conf;
 	char *filename, *strformat;
-	int versionfd, formatfd;
+	FILE *versionfd, *formatfd;
 
 	conf = config_output_dir();
 	if (conf == NULL) {
@@ -136,26 +136,26 @@ void write_cookiecrumbs_to_download_area(int version)
 	}
 
 	string_or_die(&filename, "%s/%i/swupd-server-src-version", conf, version);
-	versionfd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0664);
-	if (versionfd == -1) {
+	versionfd = fopen(filename, "w");
+	if (versionfd == NULL) {
 		assert(0);
 	}
-	if (write(versionfd, VERSION, strlen(VERSION)) != strlen(VERSION)) {
+	if (fwrite(VERSION, 1, strlen(VERSION), versionfd) != strlen(VERSION)) {
 		assert(0);
 	}
-	close(versionfd);
+	fclose(versionfd);
 	free(filename);
 
 	string_or_die(&filename, "%s/%i/format", conf, version);
 	string_or_die(&strformat, "%llu", format);
-	formatfd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0664);
-	if (formatfd == -1) {
+	formatfd = fopen(filename, "w");
+	if (formatfd == NULL) {
 		assert(0);
 	}
-	if (write(formatfd, strformat, strlen(strformat)) != (ssize_t)strlen(strformat)) {
+	if (fwrite(strformat, 1, strlen(strformat), formatfd) != strlen(strformat)) {
 		assert(0);
 	}
-	close(formatfd);
+	fclose(formatfd);
 	free(filename);
 	free(strformat);
 


### PR DESCRIPTION
There are new functions that replace system() calls: system_argv(), system_argv_fd and system_argv_pipe().
They are based on execvp() function and they can manage any argument including filenames with characters
that could be interpreted as meta-characters in a regular system() function.
So no escape for the arguments needed and is less prone to errors.

Signed-off-by: Jose R Guzman jose.r.guzman.mosqueda@intel.com
