### PR TITLE
Do not prepend empty items

### DIFF
--- a/src/create_update.c
+++ b/src/create_update.c
@@ -387,8 +387,10 @@ int main(int argc, char **argv)
 		name_includes = manifest->includes;
 		while (name_includes) {
 			char *name = name_includes->data;
+			gpointer tmp = g_hash_table_lookup(new_manifests, name);
+			if (tmp)
+				manifest_includes = g_list_prepend(manifest_includes, tmp);
 			name_includes = g_list_next(name_includes);
-			manifest_includes = g_list_prepend(manifest_includes, g_hash_table_lookup(new_manifests, name));
 		}
 		manifest->includes = manifest_includes;
 		manifest_includes = NULL;


### PR DESCRIPTION
When the item is not found, do not add it to the list.
It will cause segfaults later on, where the code
dereferences the pointer under the assumption that it is
not NULL.

Signed-off-by: Igor Stoppa igor.stoppa@intel.com
