### PR TITLE
Make directory hashes independent on filename

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -36,6 +36,8 @@
 #define TAR_PERM_ATTR_ARGS_STRLIST TAR_XATTR_ARGS_STRLIST "--preserve-permissions"
 #endif
 
+#define SWUPD_HASH_DIRNAME "DIRECTORY"
+
 #if SWUPD_WITH_STATELESS
 #define OS_IS_STATELESS 1
 #else

--- a/src/analyze_fs.c
+++ b/src/analyze_fs.c
@@ -222,7 +222,7 @@ int compute_hash(struct file *file, char *filename)
 		hmac_sha256_for_string(file->hash,
 				       (const unsigned char *)key,
 				       key_len,
-				       file->filename); //file->filename not filename
+				       SWUPD_HASH_DIRNAME); // Make independent of dirname
 		return 0;
 	}
 


### PR DESCRIPTION
Calculate the hash for directories is desiderable to be independent
on the dirname due to the subsequent calculation on the staged/HASH
file. Here is used const "DIRECTORY" string for input name for
all folders.

->
There is a patch for client side that must be applied at same time than this one
jrguzman-intel/swupd-client#73
<-

Signed-off-by: Jose R Guzman jose.r.guzman.mosqueda@intel.com
