### PR TITLE
Properly initialise includes for new manifests

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -100,6 +100,7 @@ struct manifest *alloc_manifest(int version, char *component)
 	manifest->version = version;
 	manifest->component = strdup(component);
 	manifest->format = format;
+	manifest->includes = NULL;
 
 	return manifest;
 }


### PR DESCRIPTION
Initialise the includes member to null during alloc_manifest,
otherwise when trying to access this member in a setup where
manifest includes aren't used we segfault.

Signed-off-by: Joshua Lock joshua.g.lock@intel.com
