### PR TITLE
Enable the rename feature

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -118,7 +118,8 @@ dist_check_SCRIPTS = \
 	test/functional/pack/test.bats \
 	test/functional/full-run/test.bats \
 	test/functional/full-run-delta/test.bats \
-	test/functional/file-name-blacklisted/test.bats
+	test/functional/file-name-blacklisted/test.bats \
+	test/functional/renames/test.bats
 endif
 
 if COVERAGE

--- a/Makefile.am
+++ b/Makefile.am
@@ -118,8 +118,12 @@ dist_check_SCRIPTS = \
 	test/functional/pack/test.bats \
 	test/functional/full-run/test.bats \
 	test/functional/full-run-delta/test.bats \
-	test/functional/file-name-blacklisted/test.bats \
+	test/functional/file-name-blacklisted/test.bats
+
+if RENAMES
+dist_check_SCRIPTS += \
 	test/functional/renames/test.bats
+endif
 endif
 
 if COVERAGE

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,7 @@ AM_CONDITIONAL([ENABLE_LZMA], [test "$enable_lzma" != "no"])
 AC_ARG_ENABLE([rename-detection], [AS_HELP_STRING([--enable-rename-detection], [enable rename detection feature])])
 
 AS_IF([test "$enable_rename_detection" = "yes"], [AC_DEFINE(RENAMES,1,[Use rename detection])])
+AM_CONDITIONAL([RENAMES], [test "$enable_rename_detection" = "yes"])
 
 AC_CONFIG_FILES([Makefile])
 AC_REQUIRE_AUX_FILE([tap-driver.sh])

--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,10 @@ AS_IF([test "$enable_lzma" != "no"], [
 ])
 AM_CONDITIONAL([ENABLE_LZMA], [test "$enable_lzma" != "no"])
 
+AC_ARG_ENABLE([rename-detection], [AS_HELP_STRING([--enable-rename-detection], [enable rename detection feature])])
+
+AS_IF([test "$enable_rename_detection" = "yes"], [AC_DEFINE(RENAMES,1,[Use rename detection])])
+
 AC_CONFIG_FILES([Makefile])
 AC_REQUIRE_AUX_FILE([tap-driver.sh])
 AC_OUTPUT

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -243,8 +243,8 @@ extern int previous_version_manifest(struct manifest *mom, char *name);
 
 extern void type_change_detection(struct manifest *manifest);
 
-extern void rename_detection(struct manifest *manifest, int last_change, GList *last_versions_list);
-extern void link_renames(GList *newfiles, struct manifest *from_manifest);
+extern void rename_detection(struct manifest *manifest);
+extern void link_renames(GList *newfiles, int to_version);
 extern void __create_delta(struct file *file, int from_version, char *from_hash);
 
 extern void account_delta_hit(void);

--- a/src/create_update.c
+++ b/src/create_update.c
@@ -304,8 +304,6 @@ int main(int argc, char **argv)
 	}
 
 	apply_heuristics(new_full);
-#warning disabled rename detection for some simplicity
-	// rename_detection(new_full);
 
 	print_elapsed_time("full manifest creation", &previous_time, &current_time);
 
@@ -337,11 +335,8 @@ int main(int argc, char **argv)
 		apply_heuristics(new_core);
 		/* Step 3c: ... else save the manifest */
 		type_change_detection(new_core);
-
-#warning disabled rename detection for some simplicity
-		/* Detect renamed files specifically for each pack */
-		// rename_detection(...);
-
+		/* Detect renamed files specifically for os-core */
+		rename_detection(new_core);
 		old_deleted = remove_old_deleted_files(old_core, new_core);
 		sort_manifest_by_version(new_core);
 		newfiles = prune_manifest(new_core);
@@ -443,7 +438,8 @@ int main(int argc, char **argv)
 			newm->version = oldm->version;
 		} else {
 			apply_heuristics(newm);
-#warning missing rename_detection here
+			/* Detect renamed files specifically for this bundle */
+			rename_detection(newm);
 			/* Step 6b: otherwise, write out the manifest */
 			old_deleted = remove_old_deleted_files(oldm, newm);
 			sort_manifest_by_version(newm);

--- a/src/create_update.c
+++ b/src/create_update.c
@@ -335,8 +335,10 @@ int main(int argc, char **argv)
 		apply_heuristics(new_core);
 		/* Step 3c: ... else save the manifest */
 		type_change_detection(new_core);
+#ifdef RENAMES
 		/* Detect renamed files specifically for os-core */
 		rename_detection(new_core);
+#endif
 		old_deleted = remove_old_deleted_files(old_core, new_core);
 		sort_manifest_by_version(new_core);
 		newfiles = prune_manifest(new_core);
@@ -438,8 +440,10 @@ int main(int argc, char **argv)
 			newm->version = oldm->version;
 		} else {
 			apply_heuristics(newm);
+#ifdef RENAMES
 			/* Detect renamed files specifically for this bundle */
 			rename_detection(newm);
+#endif
 			/* Step 6b: otherwise, write out the manifest */
 			old_deleted = remove_old_deleted_files(oldm, newm);
 			sort_manifest_by_version(newm);

--- a/src/pack.c
+++ b/src/pack.c
@@ -144,7 +144,7 @@ static void prepare_pack(struct packdata *pack)
 
 	match_manifests(manifest, pack->end_manifest);
 
-	link_renames(pack->end_manifest->files, manifest);
+	link_renames(pack->end_manifest->files, pack->to);
 }
 
 static void make_pack_full_files(struct packdata *pack)

--- a/src/rename.c
+++ b/src/rename.c
@@ -187,8 +187,8 @@ static void precompute_file_data(struct manifest *manifest, struct file *file)
 
 	free(filename);
 
-	file->basename = strdup(basename(file->filename));
-	file->dirname = strdup(dirname(file->filename));
+	file->basename = g_path_get_basename(file->filename);
+	file->dirname = g_path_get_dirname(file->filename);
 }
 
 int file_sort_score(gconstpointer a, gconstpointer b)

--- a/test/functional/renames/test.bats
+++ b/test/functional/renames/test.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# common functions
+load "../swupdlib"
+
+setup() {
+  clean_test_dir
+  init_test_dir
+
+  init_server_ini
+  set_latest_ver 0
+  init_groups_ini os-core test-bundle
+
+  set_os_release 10 os-core
+  track_bundle 10 os-core
+  track_bundle 10 test-bundle
+  set_os_release 20 os-core
+  track_bundle 20 os-core
+  track_bundle 20 test-bundle
+
+  # Files have different names ("foo" vs "bar"), but have the same content
+  gen_file_plain_with_content 10 test-bundle "foo" "data"
+  gen_file_plain_with_content 20 test-bundle "bar" "data"
+}
+
+@test "rename detection support" {
+  sudo $CREATE_UPDATE --osversion 10 --statedir $DIR --format 3
+  sudo $MAKE_FULLFILES --statedir $DIR 10
+  sudo $MAKE_PACK --statedir $DIR 0 10 os-core
+  sudo $MAKE_PACK --statedir $DIR 0 10 test-bundle
+
+  set_latest_ver 10
+
+  sudo $CREATE_UPDATE --osversion 20 --statedir $DIR --format 3
+  sudo $MAKE_FULLFILES --statedir $DIR 20
+  sudo $MAKE_PACK --statedir $DIR 0 20 os-core
+  sudo $MAKE_PACK --statedir $DIR 0 20 test-bundle
+  sudo $MAKE_PACK --statedir $DIR 10 20 os-core
+  sudo $MAKE_PACK --statedir $DIR 10 20 test-bundle
+
+  # A renamed file comprises a new file and a deleted file
+  [[ 1 -eq $(grep '^F\.\.r.*/bar$' $DIR/www/20/Manifest.test-bundle | wc -l) ]]
+  [[ 1 -eq $(grep '^\.d\.r.*/foo$' $DIR/www/20/Manifest.test-bundle | wc -l) ]]
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -105,4 +105,14 @@ gen_file_plain_change() {
   echo "$ver $name" > $DIR/image/$ver/$bundle/"$name"
 }
 
+gen_file_plain_with_content() {
+  local ver=$1
+  local bundle=$2
+  local name="$3"
+  local content="$4"
+
+  mkdir -p $DIR/image/$ver/$bundle
+  echo "$content" > $DIR/image/$ver/$bundle/"$name"
+}
+
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
This patch series enables the "rename" feature in swupd-server and can used by passing the --enable-rename-detection option to configure.
