### PR TITLE
Document and ship bundle status string.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ swupd_make_pack_SOURCES = \
 	src/config.c \
 	src/delta.c \
 	src/globals.c \
+	src/groups.c \
 	src/helpers.c \
 	src/log.c \
 	src/make_packs.c \
@@ -53,6 +54,7 @@ swupd_make_fullfiles_SOURCES = \
 	src/delta.c \
 	src/fullfiles.c \
 	src/globals.c \
+	src/groups.c \
 	src/helpers.c \
 	src/log.c \
 	src/make_fullfiles.c \

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -221,6 +221,7 @@ extern void read_group_file(char *filename);
 extern void release_group_file(void);
 extern char *group_groups(char *group);
 extern char *group_packages(char *group);
+extern char *group_status(char *group);
 extern char *next_group(void);
 
 extern void apply_heuristics(struct manifest *manifest);

--- a/mk_groups_ini.sh
+++ b/mk_groups_ini.sh
@@ -27,7 +27,11 @@ rm -f $SWUPD_GROUPS_INI
 
 for bundle in $(ls $BUNDLEREPO/bundles)
 do
+	status=$(awk -F: '/^# .STATUS/ {print $2}' $BUNDLEREPO/$bundle | tr -cd '[[:alnum:]]')
 	echo "[$bundle]" >> $SWUPD_GROUPS_INI
 	echo "group=$bundle" >> $SWUPD_GROUPS_INI
+	if [ -n "$status" ]; then
+		echo "status=$status" >> $SWUPD_GROUPS_INI
+	fi
 	echo "" >> $SWUPD_GROUPS_INI
 done

--- a/src/groups.c
+++ b/src/groups.c
@@ -51,6 +51,13 @@ char *group_groups(char *group)
 	return g_key_file_get_value(groupfile, group, "groups", NULL);
 }
 
+char *group_status(char *group)
+{
+	assert(groupfile != NULL);
+
+	return g_key_file_get_value(groupfile, group, "status", NULL);
+}
+
 void read_group_file(char *filename)
 {
 	GError *error = NULL;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -728,6 +728,7 @@ static int write_manifest_plain(struct manifest *manifest)
 	char *base = NULL, *dir;
 	char *conf = config_output_dir();
 	char *filename = NULL;
+	char *status = NULL;
 	char *submanifest_filename = NULL;
 	char *manifest_tempdir = NULL;
 	char *tempmanifest = NULL;
@@ -762,6 +763,10 @@ static int write_manifest_plain(struct manifest *manifest)
 	compute_content_size(manifest);
 	fprintf(out, "contentsize:\t%llu\n", (long long unsigned int)manifest->contentsize);
 	includes = manifest->includes;
+	status = group_status(manifest->component);
+	if (status) {
+		fprintf(out, "status:\t%s\n", status);
+	}
 	while (includes) {
 		struct manifest *sub = includes->data;
 		includes = g_list_next(includes);

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -35,6 +35,7 @@ init_groups_ini() {
     cat >> $DIR/groups.ini << EOF
 [$bundle]
 group=$bundle
+status=ACTIVE
 EOF
   done
 }


### PR DESCRIPTION
This patch extracts the [STATUS] field from our bundle information
metadata, and stores it in groups.ini. From there we put the contents
of this string verbatim into the manifest.

We don't interpret, encode or convert the contents of the [STATUS]
field in the manifest. Instead, we just strip non-alphanumeric
characters and pass the contents on. This leaves it entirely to the
client to parse and interpret the value of this field in the manifest.

If the bundle file, or the groups.ini file omits any status, nothing
is output to the Manifest file.
