### PR TITLE
Update for new noship dir location

### DIFF
--- a/src/analyze_fs.c
+++ b/src/analyze_fs.c
@@ -418,7 +418,7 @@ GList *get_sub_manifest_includes(char *component, int version)
 	char *included;
 	char line[8192];
 
-	conf = config_output_dir();
+	conf = config_image_base();
 	if (conf == NULL) {
 		assert(0);
 	}

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -58,9 +58,9 @@ gen_includes_file() {
   local bundle=$1
   local ver=$2
   local includes="${@:3}"
-  mkdir -p $DIR/www/$ver/noship
+  mkdir -p $DIR/image/$ver/noship
   for b in $includes; do
-    cat >> $DIR/www/$ver/noship/"$bundle"-includes << EOF
+    cat >> $DIR/image/$ver/noship/"$bundle"-includes << EOF
 $b
 EOF
   done


### PR DESCRIPTION
The bundle-chroot-builder changed the location where it stores bundle
includes metadata, so swupd-server needs to read from the new location.

Signed-off-by: Patrick McCarty patrick.mccarty@intel.com
