### PR TITLE
RFC: Ostro enhancements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ swupd_create_update_SOURCES = \
 	src/helpers.c \
 	src/heuristics.c \
 	src/log.c \
+	src/in_memory_archive.c \
 	src/manifest.c \
 	src/pack.c \
 	src/rename.c \
@@ -54,6 +55,7 @@ swupd_make_fullfiles_SOURCES = \
 	src/fullfiles.c \
 	src/globals.c \
 	src/helpers.c \
+	src/in_memory_archive.c \
 	src/log.c \
 	src/make_fullfiles.c \
 	src/manifest.c \
@@ -63,12 +65,13 @@ swupd_make_fullfiles_SOURCES = \
 	src/stats.c \
 	src/xattrs.c
 
-AM_CPPFLAGS = $(glib_CFLAGS) -I$(top_srcdir)/include
+AM_CPPFLAGS = $(glib_CFLAGS) $(libarchive_CFLAGS) -I$(top_srcdir)/include
 
 swupd_create_update_LDADD = \
 	$(glib_LIBS) \
 	$(zlib_LIBS) \
 	$(openssl_LIBS) \
+	$(libarchive_LIBS) \
 	$(bsdiff_LIBS)
 
 swupd_make_pack_LDADD = \
@@ -81,6 +84,7 @@ swupd_make_fullfiles_LDADD = \
 	$(glib_LIBS) \
 	$(zlib_LIBS) \
 	$(openssl_LIBS) \
+	$(libarchive_LIBS) \
 	$(bsdiff_LIBS)
 
 if ENABLE_LZMA

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,7 @@ AC_ARG_ENABLE(
 		AC_DEFINE([SWUPD_WITH_BSDTAR], 0, [Use default tar command])),
 	AC_DEFINE([SWUPD_WITH_BSDTAR], 0, [Use default tar command])
 )
+PKG_CHECK_MODULES([libarchive], [libarchive])
 
 AC_ARG_ENABLE(
   [tests],

--- a/include/libarchive_helper.h
+++ b/include/libarchive_helper.h
@@ -1,0 +1,42 @@
+/*
+ *   Software Updater - server side
+ *
+ *      Copyright © 2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Patrick Ohly <patrick.ohly@intel.com>
+ *
+ */
+
+#ifndef __INCLUDE_GUARD_LIBARCHIVE_HELPER_H
+#define __INCLUDE_GUARD_LIBARCHIVE_HELPER_H
+
+#include <archive.h>
+#include <stdint.h>
+
+/*
+ * Used by archive_write_open() callbacks to store the resulting archive in memory.
+ */
+struct in_memory_archive {
+	uint8_t *buffer;
+	size_t allocated;
+	size_t used;
+	/* If not 0, aborts writing when the used data would become larger than this. */
+	size_t maxsize;
+};
+
+ssize_t in_memory_write(struct archive *, void *client_data, const void *buffer, size_t length);
+
+#endif /* __INCLUDE_GUARD_LIBARCHIVE_HELPER_H */

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -20,12 +20,12 @@
 #define TAR_COMMAND "bsdtar"
 #define TAR_XATTR_ARGS ""
 #define TAR_XATTR_ARGS_STRLIST
-#define TAR_WARN_ARGS ""
+#define TAR_WARN_ARGS_STRLIST
 #else
 #define TAR_COMMAND "tar"
 #define TAR_XATTR_ARGS "--xattrs --xattrs-include='*'"
 #define TAR_XATTR_ARGS_STRLIST "--xattrs", "--xattrs-include='*'",
-#define TAR_WARN_ARGS "--warning=no-timestamp"
+#define TAR_WARN_ARGS_STRLIST "--warning=no-timestamp",
 #endif
 
 #if SWUPD_WITH_SELINUX

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -147,12 +147,14 @@ extern char *state_dir;
 extern char *packstage_dir;
 extern char *image_dir;
 extern char *staging_dir;
+extern char *manifest_cmd;
 
 extern bool init_globals(void);
 extern void free_globals(void);
 extern bool set_format(char *);
 extern void check_root(void);
 extern bool set_state_dir(char *);
+extern bool set_manifest_cmd(const char *cmd);
 extern bool init_state_globals(void);
 extern void free_state_globals(void);
 

--- a/src/analyze_fs.c
+++ b/src/analyze_fs.c
@@ -387,6 +387,9 @@ struct manifest *full_manifest_from_directory(int version)
 {
 	struct manifest *manifest;
 	char *dir;
+	int numthreads = getenv("SWUPD_NUM_THREADS") ?
+		atoi(getenv("SWUPD_NUM_THREADS")) :
+		sysconf(_SC_NPROCESSORS_ONLN);
 
 	LOG(NULL, "Computing hashes", "for %i/full", version);
 
@@ -394,7 +397,7 @@ struct manifest *full_manifest_from_directory(int version)
 
 	string_or_die(&dir, "%s/%i/full", image_dir, version);
 
-	threadpool = g_thread_pool_new(get_hash, dir, 12, FALSE, NULL);
+	threadpool = g_thread_pool_new(get_hash, dir, numthreads, FALSE, NULL);
 
 	iterate_directory(manifest, dir, "", true);
 

--- a/src/analyze_fs.c
+++ b/src/analyze_fs.c
@@ -275,7 +275,7 @@ static void get_hash(gpointer data, gpointer user_data)
 /* disallow characters which can do unexpected things when the filename is
  * used on a tar command line via system("tar [args] filename [more args]");
  */
-static bool illegal_characters(char *filename)
+static bool illegal_characters(const char *filename)
 {
 	char c;
 	int i;
@@ -301,25 +301,145 @@ static bool illegal_characters(char *filename)
 	return false;
 }
 
+static void add_file(struct manifest *manifest,
+		     const char *entry_name,
+		     char *sub_filename,
+		     char *fullname,
+		     bool do_hash)
+{
+	GError *err = NULL;
+	struct file *file;
+
+	if (illegal_characters(entry_name)) {
+		printf("WARNING: Filename %s includes illegal character(s) ...skipping.\n", sub_filename);
+		free(sub_filename);
+		free(fullname);
+		return;
+	}
+
+	file = calloc(1, sizeof(struct file));
+	assert(file);
+
+	file->last_change = manifest->version;
+	file->filename = sub_filename;
+
+	populate_file_struct(file, fullname);
+	if (file->is_deleted) {
+		/*
+		 * populate_file_struct() logs a stat() failure, but
+		 * does not abort. When adding files that should
+		 * exist, this case is an error.
+		 */
+		LOG(NULL, "file not found", "%s", fullname);
+		assert(0);
+	}
+
+
+	/* if for some reason there is a file in the official build
+	 * which should not be included in the Manifest, then open a bug
+	 * to get it removed, and work around its presence by
+	 * excluding it here, eg:
+	 if (strncmp(file->filename, "/dev/", 5) == 0) {
+	 continue;
+	 }
+	*/
+
+	if (do_hash) {
+		/* compute the hash from a thread */
+		int ret;
+		ret = g_thread_pool_push(threadpool, file, &err);
+		if (ret == FALSE) {
+			printf("GThread hash computation push error\n");
+			printf("%s\n", err->message);
+			assert(0);
+		}
+	}
+	manifest->files = g_list_prepend(manifest->files, file);
+	manifest->count++;
+}
+
+
 static void iterate_directory(struct manifest *manifest, char *pathprefix,
 			      char *subpath, bool do_hash)
 {
 	DIR *dir;
 	struct dirent *entry;
 	char *fullpath;
-	int ret;
-	GError *err = NULL;
 
 	string_or_die(&fullpath, "%s/%s", pathprefix, subpath);
 
 	dir = opendir(fullpath);
 	if (!dir) {
+		FILE *content;
+		int len;
 		free(fullpath);
+		if (errno != ENOENT) {
+			return;
+		}
+		/*
+		 * If there is a <dir>.content.txt instead of
+		 * the actual directory, then read that
+		 * file. It has a list of path names,
+		 * including all directories. The
+		 * corresponding file system entry is then
+		 * expected to be in a pre-populated "full"
+		 * directory.
+		 */
+		if (subpath[0]) {
+			string_or_die(&fullpath, "%s/%s.content.txt", pathprefix, len, subpath);
+		} else {
+			string_or_die(&fullpath, "%s.content.txt", pathprefix);
+		}
+		content = fopen(fullpath, "r");
+		free(fullpath);
+		fullpath = NULL;
+		if (content) {
+			char *line = NULL;
+			size_t len = 0;
+			ssize_t read;
+			const char *full;
+			int full_len;
+			/*
+			 * determine path to "full" directory: it is assumed to be alongside
+			 * "pathprefix", i.e. pathprefix/../full. But pathprefix does not exit,
+			 * so we have to strip the last path component.
+			 */
+			full = strrchr(pathprefix, '/');
+			if (full) {
+				full_len = full - pathprefix + 1;
+				full = pathprefix;
+			} else {
+				full = "";
+				full_len = 0;
+			}
+			while ((read = getline(&line, &len, content)) != -1) {
+				if (read) {
+					const char *entry_name = strrchr(line, '/');
+					if (entry_name) {
+						entry_name++;
+					} else {
+						entry_name = line;
+					}
+					if (line[read - 1] == '\n') {
+						line[read - 1] = 0;
+					}
+					string_or_die(&fullpath, "%.*sfull/%s", full_len, full, line);
+					add_file(manifest,
+						 entry_name,
+						 strdup(line),
+						 fullpath,
+						 do_hash);
+				}
+			}
+			free(line);
+		}
+
+		// If both directory and content file are missing, silently (?)
+		// don't add anything to the manifest.
 		return;
 	}
 
 	while (dir) {
-		struct file *file;
 		char *sub_filename;
 		char *fullname;
 
@@ -334,50 +454,13 @@ static void iterate_directory(struct manifest *manifest, char *pathprefix,
 		}
 
 		string_or_die(&sub_filename, "%s/%s", subpath, entry->d_name);
-
-		if (illegal_characters(entry->d_name)) {
-			printf("WARNING: Filename %s includes illegal character(s) ...skipping.\n", sub_filename);
-			free(sub_filename);
-			continue;
-		}
-
-		file = calloc(1, sizeof(struct file));
-		if (!file) {
-			break;
-		}
-
-		file->last_change = manifest->version;
-		file->filename = sub_filename;
-
 		string_or_die(&fullname, "%s/%s", fullpath, entry->d_name);
-		populate_file_struct(file, fullname);
-		free(fullname);
-
 		if (entry->d_type == DT_DIR) {
-			iterate_directory(manifest, pathprefix, file->filename, do_hash);
+			iterate_directory(manifest, pathprefix, sub_filename, do_hash);
 		}
+		/* takes ownership of the strings */
+		add_file(manifest, entry->d_name, sub_filename, fullname, do_hash);
 
-		/* if for some reason there is a file in the official build
-		 * which should not be included in the Manifest, then open a bug
-		 * to get it removed, and work around its presence by
-		 * excluding it here, eg:
-		if (strncmp(file->filename, "/dev/", 5) == 0) {
-			continue;
-		}
-		 */
-
-		if (do_hash) {
-			/* compute the hash from a thread */
-			ret = g_thread_pool_push(threadpool, file, &err);
-			if (ret == FALSE) {
-				printf("GThread hash computation push error\n");
-				printf("%s\n", err->message);
-				closedir(dir);
-				return;
-			}
-		}
-		manifest->files = g_list_prepend(manifest->files, file);
-		manifest->count++;
 	}
 	closedir(dir);
 	free(fullpath);

--- a/src/create_update.c
+++ b/src/create_update.c
@@ -146,6 +146,7 @@ static bool parse_options(int argc, char **argv)
 static void populate_dirs(int version)
 {
 	char *newversiondir;
+	char *newversiondircontent;
 
 	string_or_die(&newversiondir, "%s/%d", image_dir, version);
 
@@ -187,9 +188,11 @@ static void populate_dirs(int version)
 			}
 
 			string_or_die(&newversiondir, "%s/%d/%s", image_dir, version, group);
+			string_or_die(&newversiondircontent, "%s/%d/%s.content.txt", image_dir, version, group);
 
 			/* Create the bundle directory(s) as needed */
-			if (access(newversiondir, F_OK | R_OK) != 0) {
+			if (access(newversiondir, F_OK | R_OK) != 0 &&
+			    access(newversiondircontent, F_OK | R_OK) != 0) {
 				printf("%s does not exist...creating\n", group);
 				if (mkdir(newversiondir, 0755) != 0) {
 					printf("Failed to create %s subdirectory\n", group);
@@ -198,6 +201,7 @@ static void populate_dirs(int version)
 		}
 	}
 	free(newversiondir);
+	free(newversiondircontent);
 }
 
 static int check_build_env(void)

--- a/src/create_update.c
+++ b/src/create_update.c
@@ -57,6 +57,7 @@ static const struct option prog_opts[] = {
 	{ "getformat", no_argument, 0, 'g' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ "signcontent", no_argument, 0, 's' },
+	{ "manifestcmd", required_argument, 0, 'M' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -76,6 +77,7 @@ static void print_help(const char *name)
 	printf("   -g, --getformat         Print current format string and exit\n");
 	printf("   -S, --statedir          Optional directory to use for state [ default:=%s ]\n", SWUPD_SERVER_STATE_DIR);
 	printf("   -s, --signcontent       Enables cryptographic signing of update content\n");
+	printf("   -M, --manifestcmd       External command which gets invoked for each new Manifest file");
 	printf("\n");
 }
 
@@ -132,6 +134,12 @@ static bool parse_options(int argc, char **argv)
 			exit(0);
 		case 's':
 			enable_signing = true;
+			break;
+		case 'M':
+			if (!optarg || !set_manifest_cmd(optarg)) {
+				printf("Invalid --manifestcmd argument: ''%s''\n\n", optarg);
+				return false;
+			}
 			break;
 		}
 	}

--- a/src/create_update.c
+++ b/src/create_update.c
@@ -49,6 +49,7 @@ static void banner(void)
 static const struct option prog_opts[] = {
 	{ "help", no_argument, 0, 'h' },
 	{ "version", no_argument, 0, 'v' },
+	{ "log-stdout", no_argument, 0, 'l' },
 	{ "osversion", required_argument, 0, 'o' },
 	{ "minversion", required_argument, 0, 'm' },
 	{ "format", required_argument, 0, 'F' },
@@ -67,6 +68,7 @@ static void print_help(const char *name)
 	printf("   -v, --version           Show software version\n");
 	printf("\n");
 	printf("Application Options:\n");
+	printf("   -l, --log-stdout        Write log messages also to stdout\n");
 	printf("   -o, --osversion         The OS version for which to create an update\n");
 	printf("   -m, --minversion        Optional minimum file version to write into manifests per file\n");
 	printf("   -F, --format            Format number for the update\n");
@@ -86,6 +88,9 @@ static bool parse_options(int argc, char **argv)
 		case 'h':
 			print_help(argv[0]);
 			return false;
+		case 'l':
+			init_log_stdout();
+			break;
 		case 'v':
 			banner();
 			return false;

--- a/src/create_update.c
+++ b/src/create_update.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <glib.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -244,6 +245,11 @@ int main(int argc, char **argv)
 
 	/* keep valgrind working well */
 	setenv("G_SLICE", "always-malloc", 0);
+
+	if (!setlocale(LC_ALL, "")) {
+		fprintf(stderr, "%s: setlocale() failed\n", argv[0]);
+		return EXIT_FAILURE;
+	}
 
 	if (!parse_options(argc, argv)) {
 		free_globals();

--- a/src/fullfiles.c
+++ b/src/fullfiles.c
@@ -22,6 +22,8 @@
  */
 
 #define _GNU_SOURCE
+#include <archive.h>
+#include <archive_entry.h>
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -33,24 +35,27 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/xattr.h>
 #include <unistd.h>
 
 #include "swupd.h"
+#include "libarchive_helper.h"
 
 /* output must be a file, which is a (compressed) tar file, of the file denoted by "file", without any of its
    directory paths etc etc */
 static void create_fullfile(struct file *file)
 {
-	char *origin;
+	char *origin = NULL;
 	char *tarname = NULL;
-	char *rename_source = NULL;
-	char *rename_target = NULL;
-	char *rename_tmpdir = NULL;
-	int ret;
 	struct stat sbuf;
 	char *empty, *indir, *outdir;
-	char *param1, *param2;
-	int stderrfd;
+	struct archive_entry *entry = NULL;
+	struct archive *from = NULL, *to = NULL;
+	struct in_memory_archive best = { .buffer = NULL };
+	struct in_memory_archive current = { .buffer = NULL };
+	uint8_t *file_content = NULL;
+	size_t file_size;
+	int fd = -1;
 
 	if (file->is_deleted) {
 		return; /* file got deleted -> by definition we cannot tar it up */
@@ -59,15 +64,17 @@ static void create_fullfile(struct file *file)
 	empty = config_empty_dir();
 	indir = config_image_base();
 	outdir = config_output_dir();
+	entry = archive_entry_new();
+	assert(entry);
+	from = archive_read_disk_new();
+	assert(from);
 
 	string_or_die(&tarname, "%s/%i/files/%s.tar", outdir, file->last_change, file->hash);
 	if (access(tarname, R_OK) == 0) {
 		/* output file already exists...done */
-		free(tarname);
+		goto done;
 		return;
 	}
-	free(tarname);
-	//printf("%s was missing\n", file->hash);
 
 	string_or_die(&origin, "%s/%i/full/%s", indir, file->last_change, file->filename);
 	if (lstat(origin, &sbuf) < 0) {
@@ -76,156 +83,195 @@ static void create_fullfile(struct file *file)
 		assert(0);
 	}
 
-	if (file->is_dir) { /* directories are easy */
-		char *tmp1, *tmp2, *dir, *base;
+	/* step 1: tar it with each compression type  */
+	typedef int (*filter_t)(struct archive *);
+	static const filter_t compression_filters[] = {
+		/*
+		 * Start with the compression method that is most likely (*) to produce
+		 * the best result. That will allow aborting creation of archives earlier
+		 * when they become larger than the currently smallest archive.
+		 *
+		 * (*) statistics for ostro-image-swupd:
+		 *     43682 LZMA
+		 *     13398 gzip
+		 *       844 bzip2
+		 */
+		archive_write_add_filter_lzma,
+		archive_write_add_filter_gzip,
+		archive_write_add_filter_bzip2,
+		/*
+		 * TODO (?): can archive_write_add_filter_none ever be better than compressing?
+		 */
+		NULL
+	};
+	file_size = S_ISREG(sbuf.st_mode) ? sbuf.st_size : 0;
 
-		tmp1 = strdup(origin);
-		assert(tmp1);
-		base = basename(tmp1);
-
-		tmp2 = strdup(origin);
-		assert(tmp2);
-		dir = dirname(tmp2);
-
-		string_or_die(&rename_tmpdir, "%s/XXXXXX", outdir);
-		if (!mkdtemp(rename_tmpdir)) {
-			LOG(NULL, "Failed to create temporary directory for %s move", origin);
+	archive_entry_copy_sourcepath(entry, origin);
+	if (archive_read_disk_entry_from_file(from, entry, -1, &sbuf)) {
+		LOG(NULL, "Getting directory attributes failed", "%s: %s",
+		    origin, archive_error_string(from));
+		assert(0);
+	}
+	archive_entry_copy_pathname(entry, file->hash);
+	if (file_size) {
+		file_content = malloc(file_size);
+		if (!file_content) {
+			LOG(NULL, "out of memory", "");
 			assert(0);
 		}
-
-		string_or_die(&param1, "--exclude=%s/?*", base);
-		string_or_die(&param2, "./%s", base);
-		char *const tarcfcmd[] = { TAR_COMMAND, "-C", dir, TAR_PERM_ATTR_ARGS_STRLIST, "-cf", "-", param1, param2, NULL };
-		char *const tarxfcmd[] = { TAR_COMMAND, "-C", rename_tmpdir, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", "-", NULL };
-
-		stderrfd = open("/dev/null", O_WRONLY);
-		if (stderrfd == -1) {
-			LOG(NULL, "Failed to open /dev/null", "");
+		fd = open(origin, O_RDONLY);
+		if (fd == -1) {
+			LOG(NULL, "Failed to open file", "%s: %s",
+			    origin, strerror(errno));
 			assert(0);
 		}
-		if (system_argv_pipe(tarcfcmd, -1, stderrfd, tarxfcmd, -1, stderrfd) != 0) {
-			assert(0);
-		}
-		free(param1);
-		free(param2);
-		close(stderrfd);
-
-		string_or_die(&rename_source, "%s/%s", rename_tmpdir, base);
-		string_or_die(&rename_target, "%s/%s", rename_tmpdir, file->hash);
-		if (rename(rename_source, rename_target)) {
-			LOG(NULL, "rename failed for %s to %s", rename_source, rename_target);
-			assert(0);
-		}
-		free(rename_source);
-
-		/* for a directory file, tar up simply with gzip */
-		string_or_die(&param1, "%s/%i/files/%s.tar", outdir, file->last_change, file->hash);
-		char *const tarcmd[] = { TAR_COMMAND, "-C", rename_tmpdir, TAR_PERM_ATTR_ARGS_STRLIST, "-zcf", param1, file->hash, NULL };
-
-		if (system_argv(tarcmd) != 0) {
-			assert(0);
-		}
-		free(param1);
-
-		if (rmdir(rename_target)) {
-			LOG(NULL, "rmdir failed for %s", rename_target);
-		}
-		free(rename_target);
-		if (rmdir(rename_tmpdir)) {
-			LOG(NULL, "rmdir failed for %s", rename_tmpdir);
-		}
-		free(rename_tmpdir);
-
-		free(tmp1);
-		free(tmp2);
-	} else { /* files are more complex */
-		char *gzfile = NULL, *bzfile = NULL, *xzfile = NULL;
-		char *tempfile;
-		uint64_t gz_size = LONG_MAX, bz_size = LONG_MAX, xz_size = LONG_MAX;
-
-		/* step 1: hardlink the guy to an empty directory with the hash as the filename */
-		string_or_die(&tempfile, "%s/%s", empty, file->hash);
-		if (link(origin, tempfile) < 0) {
-			LOG(NULL, "hardlink failed", "%s due to %s (%s -> %s)", file->filename, strerror(errno), origin, tempfile);
-			char *const argv[] = { "cp", "-a", origin, tempfile, NULL };
-			if (system_argv(argv) != 0) {
+		size_t done = 0;
+		while (done < file_size) {
+			ssize_t curr;
+			curr = read(fd, file_content + done, file_size - done);
+			if (curr == -1) {
+				LOG(NULL, "Failed to read from file", "%s: %s",
+				    origin, strerror(errno));
 				assert(0);
 			}
+			done += curr;
 		}
-
-		/* step 2a: tar it with each compression type  */
-		// lzma
-		string_or_die(&param1, "--directory=%s", empty);
-		string_or_die(&param2, "%s/%i/files/%s.tar.xz", outdir, file->last_change, file->hash);
-		char *const tarlzmacmd[] = { TAR_COMMAND, param1, TAR_PERM_ATTR_ARGS_STRLIST, "-Jcf", param2, file->hash, NULL };
-
-		if (system_argv(tarlzmacmd) != 0) {
-			assert(0);
-		}
-		free(param1);
-		free(param2);
-
-		// gzip
-		string_or_die(&param1, "--directory=%s", empty);
-		string_or_die(&param2, "%s/%i/files/%s.tar.gz", outdir, file->last_change, file->hash);
-		char *const targzipcmd[] = { TAR_COMMAND, param1, TAR_PERM_ATTR_ARGS_STRLIST, "-zcf", param2, file->hash, NULL };
-
-		if (system_argv(targzipcmd) != 0) {
-			assert(0);
-		}
-		free(param1);
-		free(param2);
-
-#ifdef SWUPD_WITH_BZIP2
-		string_or_die(&param1, "--directory=%s", empty);
-		string_or_die(&param2, "%s/%i/files/%s.tar.bz2", outdir, file->last_change, file->hash);
-		char *const tarbzip2cmd[] = { TAR_COMMAND, param1, TAR_PERM_ATTR_ARGS_STRLIST, "-jcf", param2, file->hash, NULL };
-
-		if (system_argv(tarbzip2cmd) != 0) {
-			assert(0);
-		}
-		free(param1);
-		free(param2);
-
-#endif
-
-		/* step 2b: pick the smallest of the three compression formats */
-		string_or_die(&gzfile, "%s/%i/files/%s.tar.gz", outdir, file->last_change, file->hash);
-		if (stat(gzfile, &sbuf) == 0) {
-			gz_size = sbuf.st_size;
-		}
-		string_or_die(&bzfile, "%s/%i/files/%s.tar.bz2", outdir, file->last_change, file->hash);
-		if (stat(bzfile, &sbuf) == 0) {
-			bz_size = sbuf.st_size;
-		}
-		string_or_die(&xzfile, "%s/%i/files/%s.tar.xz", outdir, file->last_change, file->hash);
-		if (stat(xzfile, &sbuf) == 0) {
-			xz_size = sbuf.st_size;
-		}
-		string_or_die(&tarname, "%s/%i/files/%s.tar", outdir, file->last_change, file->hash);
-		if (gz_size <= xz_size && gz_size <= bz_size) {
-			ret = rename(gzfile, tarname);
-		} else if (xz_size <= bz_size) {
-			ret = rename(xzfile, tarname);
-		} else {
-			ret = rename(bzfile, tarname);
-		}
-		if (ret != 0) {
-			LOG(file, "post-tar rename failed", "ret=%d", ret);
-		}
-		unlink(bzfile);
-		unlink(xzfile);
-		unlink(gzfile);
-		free(bzfile);
-		free(xzfile);
-		free(gzfile);
-		free(tarname);
-
-		/* step 3: remove the hardlink */
-		unlink(tempfile);
-		free(tempfile);
 	}
 
+	for (int i = 0; compression_filters[i]; i++) {
+		/* Need to re-initialize the archive handle, it cannot be re-used. */
+		if (to) {
+			archive_write_free(to);
+		}
+		/*
+		 * Use the recommended restricted pax interchange
+		 * format. Numeric uid/gid values are stored in the archive
+		 * (no uid/gid lookup enabled) because symbolic names can lead
+		 * to a hash mismatch during unpacking when /etc/passwd or
+		 * /etc/group change during an update (see
+		 * https://github.com/clearlinux/swupd-client/issues/101).
+		 *
+		 * Filenames read from the file system are expected to be
+		 * valid according to the current locale. archive_write_header()
+		 * will warn about filenames that it cannot properly decode
+		 * and proceeds by writing the raw bytes, but we treat this an
+		 * error by not distinguishing between ARCHIVE_FATAL
+		 * and ARCHIVE_WARN.
+		 *
+		 * When we fail with "Can't translate" errors, make sure that
+		 * LANG and/or LC_ env variables are set.
+		 */
+		to = archive_write_new();
+		assert(to);
+		if (archive_write_set_format_pax_restricted(to)) {
+			LOG(NULL, "PAX format", "%s", archive_error_string(to));
+			assert(0);
+		}
+		do {
+			/* Try compression methods until we find one which is supported. */
+			if (!compression_filters[i](to)) {
+				break;
+			}
+		} while(compression_filters[++i]);
+		/*
+		 * Regardless of the block size below, never pad the
+		 * last block, it just makes the archive larger.
+		 */
+		if (archive_write_set_bytes_in_last_block(to, 1)) {
+			LOG(NULL, "Removing padding failed", "");
+			assert(0);
+		}
+		/*
+		 * Invoke in_memory_write() as often as possible and check each
+		 * time whether we are already larger than the currently best
+		 * algorithm.
+		 */
+		current.maxsize = best.used;
+		if (archive_write_set_bytes_per_block(to, 0)) {
+			LOG(NULL, "Removing blocking failed", "");
+			assert(0);
+		}
+		/*
+		 * We can make an educated guess how large the resulting archive will be.
+		 * Avoids realloc() calls when the file is big.
+		 */
+		if (!current.allocated) {
+			current.allocated = file_size + 4096;
+			current.buffer = malloc(current.allocated);
+		}
+		if (!current.buffer) {
+			LOG(NULL, "out of memory", "");
+			assert(0);
+		}
+		if (archive_write_open(to, &current, NULL, in_memory_write, NULL)) {
+			LOG(NULL, "Failed to create archive", "%s",
+			    archive_error_string(to));
+			assert(0);
+		}
+		if (archive_write_header(to, entry) ||
+		    file_content && archive_write_data(to, file_content, file_size) != (ssize_t)file_size ||
+		    archive_write_close(to)) {
+			if (current.maxsize && current.used >= current.maxsize) {
+				archive_write_free(to);
+				to = NULL;
+				continue;
+			}
+			LOG(NULL, "Failed to store file in archive", "%s: %s",
+			    origin, archive_error_string(to));
+			assert(0);
+		}
+		if (!best.used || current.used < best.used) {
+			free(best.buffer);
+			best = current;
+			memset(&current, 0, sizeof(current));
+		} else {
+			/* Simply re-use the buffer for the next iteration. */
+			current.used = 0;
+		}
+	}
+	if (!best.used) {
+		LOG(NULL, "creating archive failed with all compression methods", "");
+		assert(0);
+	}
+
+	/* step 2: write out to disk. Archives are immutable and thus read-only. */
+	fd = open(tarname, O_CREAT|O_WRONLY, S_IRUSR|S_IRGRP|S_IROTH);
+	if (fd <= 0) {
+		LOG(NULL, "Failed to create archive", "%s: %s",
+		    tarname, strerror(errno));
+		assert(0);
+	}
+	size_t done = 0;
+	while (done < best.used) {
+		ssize_t curr;
+		curr = write(fd, best.buffer + done, best.used - done);
+		if (curr == -1) {
+			LOG(NULL, "Failed to write archive", "%s: %s",
+			    tarname, strerror(errno));
+			assert(0);
+		}
+		done += curr;
+	}
+	if (close(fd)) {
+		LOG(NULL, "Failed to complete writing archive", "%s: %s",
+		    tarname, strerror(errno));
+		assert(0);
+	}
+	fd = -1;
+	free(best.buffer);
+	free(current.buffer);
+	free(file_content);
+
+ done:
+	if (fd >= 0) {
+		close(fd);
+	}
+	archive_read_free(from);
+	if (to) {
+		archive_write_free(to);
+	}
+	archive_entry_free(entry);
+	free(tarname);
 	free(indir);
 	free(outdir);
 	free(empty);

--- a/src/fullfiles.c
+++ b/src/fullfiles.c
@@ -72,7 +72,7 @@ static void create_fullfile(struct file *file)
 	string_or_die(&origin, "%s/%i/full/%s", indir, file->last_change, file->filename);
 	if (lstat(origin, &sbuf) < 0) {
 		/* no input file: means earlier phase of update creation failed */
-		LOG(NULL, "Failed to stat %s\n", origin);
+		LOG(NULL, "Failed to stat", "%s: %s", origin, strerror(errno));
 		assert(0);
 	}
 

--- a/src/fullfiles.c
+++ b/src/fullfiles.c
@@ -291,10 +291,13 @@ static void submit_fullfile_tasks(GList *files)
 	int ret;
 	int count = 0;
 	GError *err = NULL;
+	int numthreads = getenv("SWUPD_NUM_THREADS") ?
+		atoi(getenv("SWUPD_NUM_THREADS")) :
+		sysconf(_SC_NPROCESSORS_ONLN) * 3;
 
-	LOG(NULL, "fullfile threadpool", "%d threads", sysconf(_SC_NPROCESSORS_ONLN) * 3);
+	LOG(NULL, "fullfile threadpool", "%d threads", numthreads);
 	threadpool = g_thread_pool_new(create_fullfile_task, NULL,
-				       sysconf(_SC_NPROCESSORS_ONLN) * 3,
+				       numthreads,
 				       TRUE, NULL);
 
 	printf("Starting downloadable fullfiles data creation\n");

--- a/src/fullfiles.c
+++ b/src/fullfiles.c
@@ -136,6 +136,8 @@ static void create_fullfile(struct file *file)
 			}
 			done += curr;
 		}
+		close(fd);
+		fd = -1;
 	}
 
 	for (int i = 0; compression_filters[i]; i++) {

--- a/src/globals.c
+++ b/src/globals.c
@@ -40,6 +40,7 @@ char *state_dir = NULL;
 char *packstage_dir = NULL;
 char *image_dir = NULL;
 char *staging_dir = NULL;
+char *manifest_cmd = NULL;
 
 bool set_format(char *userinput)
 {
@@ -76,6 +77,13 @@ bool set_state_dir(char *dir)
 	return true;
 }
 
+bool set_manifest_cmd(const char *cmd)
+{
+	free(manifest_cmd);
+	manifest_cmd = strdup(cmd);
+	return true;
+}
+
 bool init_globals(void)
 {
 	if (format == 0) {
@@ -103,6 +111,7 @@ void free_globals(void)
 	free(packstage_dir);
 	free(image_dir);
 	free(staging_dir);
+	free(manifest_cmd);
 }
 
 bool init_state_globals(void)
@@ -123,4 +132,5 @@ void free_state_globals(void)
 	free(packstage_dir);
 	free(image_dir);
 	free(staging_dir);
+	free(manifest_cmd);
 }

--- a/src/in_memory_archive.c
+++ b/src/in_memory_archive.c
@@ -1,0 +1,67 @@
+/*
+ *   Software Updater - server side
+ *
+ *      Copyright © 2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Patrick Ohly <patrick.ohly@intel.com>
+ *
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include "libarchive_helper.h"
+
+ssize_t in_memory_write(struct archive *archive, void *client_data, const void *buffer, size_t length)
+{
+	struct in_memory_archive *in_memory = client_data;
+	void *newbuff;
+
+	if (in_memory->maxsize && in_memory->used + length >= in_memory->maxsize) {
+		archive_set_error(archive, EFBIG, "resulting archive would become larger than %lu",
+				  (unsigned long)in_memory->maxsize);
+		archive_write_fail(archive);
+		/*
+		 * Despite the error and archive_write_fail(), libarchive internally calls us
+		 * again and when we fail again, overwrites our error with something about
+		 * "Failed to clean up compressor". Therefore our caller needs to check for "used == maxsize"
+		 * to detect that we caused the failure.
+		 */
+		in_memory->used = in_memory->maxsize;
+		return -1;
+	}
+
+	if (in_memory->used + length > in_memory->allocated) {
+		/* Start with a small chunk, double in size to avoid too many reallocs. */
+		size_t new_size = in_memory->allocated ?
+			in_memory->allocated * 2 :
+			4096;
+		while (new_size < in_memory->used + length) {
+			new_size *= 2;
+		}
+		newbuff = realloc(in_memory->buffer, new_size);
+		if (!newbuff) {
+			archive_set_error(archive, ENOMEM, "failed to enlarge buffer");
+			return -1;
+		}
+		in_memory->buffer = newbuff;
+		in_memory->allocated = new_size;
+	}
+
+	memcpy(in_memory->buffer + in_memory->used, buffer, length);
+	in_memory->used += length;
+	return length;
+}

--- a/src/make_fullfiles.c
+++ b/src/make_fullfiles.c
@@ -32,6 +32,7 @@
 
 static const struct option prog_opts[] = {
 	{ "help", no_argument, 0, 'h' },
+	{ "log-stdout", no_argument, 0, 'l' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
@@ -42,6 +43,7 @@ static void usage(const char *name)
 	printf("   %s <version>\n\n", name);
 	printf("Help options:\n");
 	printf("   -h, --help              Show help options\n");
+	printf("   -l, --log-stdout        Write log messages also to stdout\n");
 	printf("   -S, --statedir          Optional directory to use for state [ default:=%s ]\n", SWUPD_SERVER_STATE_DIR);
 	printf("\n");
 }
@@ -56,6 +58,9 @@ static bool parse_options(int argc, char **argv)
 		case 'h':
 			usage(argv[0]);
 			return false;
+		case 'l':
+			init_log_stdout();
+			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
 				printf("Invalid --statedir argument '%s'\n\n", optarg);

--- a/src/make_fullfiles.c
+++ b/src/make_fullfiles.c
@@ -23,6 +23,7 @@
 #define _GNU_SOURCE
 #include <assert.h>
 #include <getopt.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -92,6 +93,11 @@ int main(int argc, char **argv)
 
 	/* keep valgrind working well */
 	setenv("G_SLICE", "always-malloc", 0);
+
+	if (!setlocale(LC_ALL, "")) {
+		fprintf(stderr, "%s: setlocale() failed\n", argv[0]);
+		return EXIT_FAILURE;
+	}
 
 	if (!parse_options(argc, argv)) {
 		free_state_globals();

--- a/src/make_packs.c
+++ b/src/make_packs.c
@@ -27,6 +27,7 @@
 #include <getopt.h>
 #include <getopt.h>
 #include <glib.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -105,6 +106,11 @@ int main(int argc, char **argv)
 	struct packdata *pack;
 	int exit_status = EXIT_FAILURE;
 	char *file_path = NULL;
+
+	if (!setlocale(LC_ALL, "")) {
+		fprintf(stderr, "%s: setlocale() failed\n", argv[0]);
+		return EXIT_FAILURE;
+	}
 
 	if (!parse_options(argc, argv)) {
 		free_state_globals();

--- a/src/make_packs.c
+++ b/src/make_packs.c
@@ -45,6 +45,7 @@ static void banner(void)
 
 static const struct option prog_opts[] = {
 	{ "help", no_argument, 0, 'h' },
+	{ "log-stdout", no_argument, 0, 'l' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ "signcontent", no_argument, 0, 's' },
 	{ 0, 0, 0, 0 }
@@ -56,6 +57,7 @@ static void usage(const char *name)
 	printf("   %s <start version> <latest version> <bundle>\n\n", name);
 	printf("Help options:\n");
 	printf("   -h, --help              Show help options\n");
+	printf("   -l, --log-stdout        Write log messages also to stdout\n");
 	printf("   -S, --statedir          Optional directory to use for state [ default:=%s ]\n", SWUPD_SERVER_STATE_DIR);
 	printf("   -s, --signcontent       Enables cryptographic signing of update content\n");
 	printf("\n");
@@ -71,6 +73,9 @@ static bool parse_options(int argc, char **argv)
 		case 'h':
 			usage(argv[0]);
 			return false;
+		case 'l':
+			init_log_stdout();
+			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
 				printf("Invalid --statedir argument ''%s'\n\n", optarg);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -825,6 +825,17 @@ static int write_manifest_plain(struct manifest *manifest)
 		free(submanifest_filename);
 	}
 
+	if (manifest_cmd) {
+		fclose(out);
+		out = NULL;
+
+		char *const cmd[] = { manifest_cmd, filename, NULL };
+		int cmdret = system_argv(cmd);
+		if (cmdret != 0) {
+			assert(0);
+		}
+	}
+
 	ret = 0;
 exit:
 	if (manifest_tempdir) {

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -812,6 +812,11 @@ static int write_manifest_plain(struct manifest *manifest)
 		}
 
 		string_or_die(&tempmanifest, "%s/Manifest.%s", manifest_tempdir, file->filename);
+		/*
+		 * use_xattr Has to match swupd-client:
+		 * there it is enabled unconditionally in verify_file().
+		 */
+		file->use_xattrs = true;
 		populate_file_struct(file, tempmanifest);
 		ret = compute_hash(file, tempmanifest);
 		if (ret != 0) {

--- a/src/pack.c
+++ b/src/pack.c
@@ -116,7 +116,7 @@ static void explode_pack_stage(int from_version, int to_version, char *module)
 		 * time on the client...
 		 */
 		string_or_die(&param, "%s/%s/%i_to_%i/staged", packstage_dir, module, from_version, to_version);
-		char *const tarcmd[] = { TAR_COMMAND, "-C", param, TAR_WARN_ARGS, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", path, NULL };
+		char *const tarcmd[] = { TAR_COMMAND, "-C", param, TAR_WARN_ARGS_STRLIST TAR_PERM_ATTR_ARGS_STRLIST, "-xf", path, NULL };
 		if (system_argv(tarcmd) == 0) {
 			unlink(path);
 		}

--- a/src/pack.c
+++ b/src/pack.c
@@ -285,10 +285,13 @@ static void make_pack_deltas(GList *files)
 	struct file *file;
 	int ret;
 	GError *err = NULL;
+	int numthreads = getenv("SWUPD_NUM_THREADS") ?
+		atoi(getenv("SWUPD_NUM_THREADS")) :
+		sysconf(_SC_NPROCESSORS_ONLN);
 
-	LOG(NULL, "pack deltas threadpool", "%d threads", sysconf(_SC_NPROCESSORS_ONLN));
+	LOG(NULL, "pack deltas threadpool", "%d threads", numthreads);
 	threadpool = g_thread_pool_new(create_delta, NULL,
-				       sysconf(_SC_NPROCESSORS_ONLN), FALSE, NULL);
+				       numthreads, FALSE, NULL);
 
 	item = g_list_first(files);
 	while (item) {


### PR DESCRIPTION
This is the result of my work on addressing the performance problems that Ostro had with swupd. Where previously image creation took over 4 hours, it's now down to a bit more than half an hour. Not all of that came from these swupd-server enhancements, but a significant part.

The first four patches are hopefully uncontroversial and ready to be merged; I can submit them separately in a PR if you agree, or you can just merge manually from my branch.

The commit that will require more thought and/or work is "fullfiles: use libarchive directly". Right now this change is unconditional, i.e. it also changes the output when bsdtar is not explicitly requested during compilation. I did that because the new code is simpler and you might want to use it instead of the old one. My hope is that this won't cause problems in practice for Clear because GNU tar on Clear might (should?) be able to unpack the .tar archives without problems. That's based on the assumption that you don't have xattrs (which are known to be stored in an incompatible way) and that long file names are okay. But I haven't tested that. Can you check that using some real Clear build?

If you can't and/or don't want to change, would a patch with ifdefs be acceptable, i.e. only call libarchive directly when bsdtar is enabled?

"swupd-create-update: alternative input layout" should not change anything when using the traditional input layout. The patch itself is a bit larger because it moves some code into the add_file() utility method.

Finally, the manifest hash patches ("swupd_create_update: call external command for each manifest" and "swupd-server: include xattrs in manifest hash"): they are necessary if we want to check xattrs set for manifest files. I'm undecided myself whether that's really needed. It might be simpler to just patch the swupd-client's verify_file() method.

However, setting the security.IMA xattr via an external command might have some advantages even when not checking the xattr, so I'd prefer to get at least that one merged.

@rojkov @incandescant @igor-stoppa: FYI, this patch review is required before https://github.com/ostroproject/ostro-os/pull/198 can proceed.
