### PR TITLE
swupd_create_fullfiles: avoid segfault when nothing changes

### DIFF
--- a/src/fullfiles.c
+++ b/src/fullfiles.c
@@ -252,7 +252,7 @@ static GList *get_deduplicated_fullfile_list(struct manifest *manifest)
 	manifest->files = g_list_sort(manifest->files, file_sort_hash);
 
 	list = g_list_first(manifest->files);
-	while (prev == NULL) {
+	while (prev == NULL && list != NULL) {
 		tmp = list->data;
 		list = g_list_next(list);
 


### PR DESCRIPTION
In the (unlikely) case that nothing changed between two builds,
get_deduplicated_fullfile_list() segfaults because it uses
manifest->files without checking for NULL, aka the empty list.