### PR TITLE
delta.c: fix xattr test after patching

### DIFF
--- a/src/delta.c
+++ b/src/delta.c
@@ -97,7 +97,7 @@ void __create_delta(struct file *file, int from_version, char *from_hash)
 		ret = 0;
 		goto out;
 	}
-	xattrs_copy(original, newfile);
+	xattrs_copy(original, testnewfile);
 
 	/* does xattrs have been correctly copied?*/
 	if (xattrs_compare(original, testnewfile) != 0) {


### PR DESCRIPTION
At the moment, swupd_create_pack fails when some files have xattrs and
get patched because the xattrs of the test file do not match the
original, unpatched file.

That's because xattrs_copy() was applied to the wrong target file.

Fixes: swupd-server/#35