### PR TITLE
Switch secondary sort order for version-sorted manifests

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -64,7 +64,7 @@ int file_sort_version(gconstpointer a, gconstpointer b)
 		return 1;
 	}
 
-	return strcmp(B->filename, A->filename);
+	return strcmp(A->filename, B->filename);
 }
 
 int file_sort_filename(gconstpointer a, gconstpointer b)


### PR DESCRIPTION
To ease human readability of manifests, but without impacting manifest
delta efficiency, use a lexicographic filename secondary sort order when
sorting manifests by version.

Below is an example of how this commit changes the sorted order (the
first column is the version, and the second column is the filename).

```
# Before
10	zyxw
10	abcd
20	test2
20	test1
20	abba
20	aaaa
30	zzyy

# After
10	abcd
10	zyxw
20	aaaa
20	abba
20	test1
20	test2
30	zzyy
```