### PR TITLE
Fix fallthrough state detection logic

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -118,7 +118,8 @@ dist_check_SCRIPTS = \
 	test/functional/pack/test.bats \
 	test/functional/full-run/test.bats \
 	test/functional/full-run-delta/test.bats \
-	test/functional/file-name-blacklisted/test.bats
+	test/functional/file-name-blacklisted/test.bats \
+	test/functional/state-file/test.bats
 endif
 
 if COVERAGE

--- a/src/heuristics.c
+++ b/src/heuristics.c
@@ -44,15 +44,15 @@ static void runtime_state_heuristics(struct file *file)
 {
 	/* these are shipped directories that are not themselves state,
 	 * rather only their contents are state */
-	if ((strncmp(file->filename, "/usr/src/debug", 14) == 0) ||
-	    (strncmp(file->filename, "/dev", 4) == 0) ||
-	    (strncmp(file->filename, "/home", 5) == 0) ||
-	    (strncmp(file->filename, "/proc", 5) == 0) ||
-	    (strncmp(file->filename, "/root", 5) == 0) ||
-	    (strncmp(file->filename, "/run", 4) == 0) ||
-	    (strncmp(file->filename, "/sys", 4) == 0) ||
-	    (strncmp(file->filename, "/tmp", 4) == 0) ||
-	    (strncmp(file->filename, "/var", 4) == 0)) {
+	if ((strcmp(file->filename, "/usr/src/debug") == 0) ||
+	    (strcmp(file->filename, "/dev") == 0) ||
+	    (strcmp(file->filename, "/home") == 0) ||
+	    (strcmp(file->filename, "/proc") == 0) ||
+	    (strcmp(file->filename, "/root") == 0) ||
+	    (strcmp(file->filename, "/run") == 0) ||
+	    (strcmp(file->filename, "/sys") == 0) ||
+	    (strcmp(file->filename, "/tmp") == 0) ||
+	    (strcmp(file->filename, "/var") == 0)) {
 		return;
 	}
 

--- a/test/functional/state-file/test.bats
+++ b/test/functional/state-file/test.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+# common functions
+load "../swupdlib"
+
+setup() {
+  clean_test_dir
+  init_test_dir
+
+  init_server_ini
+  set_latest_ver 0
+  init_groups_ini os-core
+
+  set_os_release 10 os-core
+  track_bundle 10 os-core
+
+  gen_file_plain 10 os-core "/var/lib/test"
+}
+
+@test "state file marked in manifest" {
+  sudo $CREATE_UPDATE --osversion 10 --statedir $DIR --format 3
+
+  # a file and dir installed in /var should be marked state
+  grep '^D\.s\..*/var/lib$' $DIR/www/10/Manifest.os-core
+  grep '^F\.s\..*/var/lib/test$' $DIR/www/10/Manifest.os-core
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -91,7 +91,7 @@ gen_file_plain() {
   local name="$3"
 
   # Add plain text file into a bundle
-  mkdir -p $DIR/image/$ver/$bundle
+  mkdir -p $DIR/image/$ver/$bundle/$(dirname "$name")
   echo "$name" > $DIR/image/$ver/$bundle/"$name"
 }
 
@@ -101,7 +101,7 @@ gen_file_plain_change() {
   local name="$3"
 
   # Add plain text file into a bundle
-  mkdir -p $DIR/image/$ver/$bundle
+  mkdir -p $DIR/image/$ver/$bundle/$(dirname "$name")
   echo "$ver $name" > $DIR/image/$ver/$bundle/"$name"
 }
 


### PR DESCRIPTION
This conditional checks for state *directories* that are generally
installed by default, and the conditional immediately below this one
checks for state files within these directories. So, if we do strncmp()
instead of strcmp(), the fallthrough logic doesn't occur, and state
files are not marked as such.

This reverts commit 63fb5fb61bc95525635deb2b0f4bdbf9d1e0e1ae.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>