### PR TITLE
fullfiles.c: fix invalid LOG() call

### DIFF
--- a/src/fullfiles.c
+++ b/src/fullfiles.c
@@ -72,7 +72,7 @@ static void create_fullfile(struct file *file)
 	string_or_die(&origin, "%s/%i/full/%s", indir, file->last_change, file->filename);
 	if (lstat(origin, &sbuf) < 0) {
 		/* no input file: means earlier phase of update creation failed */
-		LOG(NULL, "Failed to stat %s\n", origin);
+		LOG(NULL, "Failed to stat", "%s: %s", origin, strerror(errno));
 		assert(0);
 	}
 


### PR DESCRIPTION
LOG() takes an additional fixed string before the format string.

Already reviewed here: https://github.com/clearlinux/swupd-server/pull/34

IMHO it would be good to add printf format function attributes to the
logging functions, to catch such errors and also mismatches between
the format string and the actual parameters.

https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes