### PR TITLE
enable locales in all programs

### DIFF
--- a/src/create_update.c
+++ b/src/create_update.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <glib.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -258,6 +259,11 @@ int main(int argc, char **argv)
 
 	/* keep valgrind working well */
 	setenv("G_SLICE", "always-malloc", 0);
+
+	if (!setlocale(LC_ALL, "")) {
+		fprintf(stderr, "%s: setlocale() failed\n", argv[0]);
+		return EXIT_FAILURE;
+	}
 
 	if (!parse_options(argc, argv)) {
 		free_globals();

--- a/src/make_fullfiles.c
+++ b/src/make_fullfiles.c
@@ -23,6 +23,7 @@
 #define _GNU_SOURCE
 #include <assert.h>
 #include <getopt.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -87,6 +88,11 @@ int main(int argc, char **argv)
 
 	/* keep valgrind working well */
 	setenv("G_SLICE", "always-malloc", 0);
+
+	if (!setlocale(LC_ALL, "")) {
+		fprintf(stderr, "%s: setlocale() failed\n", argv[0]);
+		return EXIT_FAILURE;
+	}
 
 	if (!parse_options(argc, argv)) {
 		free_state_globals();

--- a/src/make_packs.c
+++ b/src/make_packs.c
@@ -27,6 +27,7 @@
 #include <getopt.h>
 #include <getopt.h>
 #include <glib.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -100,6 +101,11 @@ int main(int argc, char **argv)
 	struct packdata *pack;
 	int exit_status = EXIT_FAILURE;
 	char *file_path = NULL;
+
+	if (!setlocale(LC_ALL, "")) {
+		fprintf(stderr, "%s: setlocale() failed\n", argv[0]);
+		return EXIT_FAILURE;
+	}
 
 	if (!parse_options(argc, argv)) {
 		free_state_globals();


### PR DESCRIPTION
This is a pre-condition for using libarchive directly: libarchive
needs to know what the encoding of filenames is, and it uses the
current locale for that. Without setlocale(), the locale is "C", which
only supports ASCII filenames, leading to warnings about "Can't
encode..." from libarchive when it is forced to fall back to copying
strings verbatim when writing archives that require UTF-8 encoding.

As a side effect, error messages from libc will get translated
according to the user's environment.

I'm submitting this separately from the libarchive changes because I
find it useful also without those and merging it now would reduce the
number of non-upstream patches.