### PR TITLE
add logging to stdout

### DIFF
--- a/src/create_update.c
+++ b/src/create_update.c
@@ -49,6 +49,7 @@ static void banner(void)
 static const struct option prog_opts[] = {
 	{ "help", no_argument, 0, 'h' },
 	{ "version", no_argument, 0, 'v' },
+	{ "log-stdout", no_argument, 0, 'l' },
 	{ "osversion", required_argument, 0, 'o' },
 	{ "minversion", required_argument, 0, 'm' },
 	{ "format", required_argument, 0, 'F' },
@@ -67,6 +68,7 @@ static void print_help(const char *name)
 	printf("   -v, --version           Show software version\n");
 	printf("\n");
 	printf("Application Options:\n");
+	printf("   -l, --log-stdout        Write log messages also to stdout\n");
 	printf("   -o, --osversion         The OS version for which to create an update\n");
 	printf("   -m, --minversion        Optional minimum file version to write into manifests per file\n");
 	printf("   -F, --format            Format number for the update\n");
@@ -86,6 +88,9 @@ static bool parse_options(int argc, char **argv)
 		case 'h':
 			print_help(argv[0]);
 			return false;
+		case 'l':
+			init_log_stdout();
+			break;
 		case 'v':
 			banner();
 			return false;

--- a/src/make_fullfiles.c
+++ b/src/make_fullfiles.c
@@ -32,6 +32,7 @@
 
 static const struct option prog_opts[] = {
 	{ "help", no_argument, 0, 'h' },
+	{ "log-stdout", no_argument, 0, 'l' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
@@ -42,6 +43,7 @@ static void usage(const char *name)
 	printf("   %s <version>\n\n", name);
 	printf("Help options:\n");
 	printf("   -h, --help              Show help options\n");
+	printf("   -l, --log-stdout        Write log messages also to stdout\n");
 	printf("   -S, --statedir          Optional directory to use for state [ default:=%s ]\n", SWUPD_SERVER_STATE_DIR);
 	printf("\n");
 }
@@ -56,6 +58,9 @@ static bool parse_options(int argc, char **argv)
 		case 'h':
 			usage(argv[0]);
 			return false;
+		case 'l':
+			init_log_stdout();
+			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
 				printf("Invalid --statedir argument '%s'\n\n", optarg);

--- a/src/make_packs.c
+++ b/src/make_packs.c
@@ -45,6 +45,7 @@ static void banner(void)
 
 static const struct option prog_opts[] = {
 	{ "help", no_argument, 0, 'h' },
+	{ "log-stdout", no_argument, 0, 'l' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ "signcontent", no_argument, 0, 's' },
 	{ 0, 0, 0, 0 }
@@ -56,6 +57,7 @@ static void usage(const char *name)
 	printf("   %s <start version> <latest version> <bundle>\n\n", name);
 	printf("Help options:\n");
 	printf("   -h, --help              Show help options\n");
+	printf("   -l, --log-stdout        Write log messages also to stdout\n");
 	printf("   -S, --statedir          Optional directory to use for state [ default:=%s ]\n", SWUPD_SERVER_STATE_DIR);
 	printf("   -s, --signcontent       Enables cryptographic signing of update content\n");
 	printf("\n");
@@ -71,6 +73,9 @@ static bool parse_options(int argc, char **argv)
 		case 'h':
 			usage(argv[0]);
 			return false;
+		case 'l':
+			init_log_stdout();
+			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
 				printf("Invalid --statedir argument ''%s'\n\n", optarg);


### PR DESCRIPTION
When a CI system (like the one from Ostro) captures the output of
commands, but not necessarily intermediate log files, then it is
useful to also log to stdout. Another use case is calling the tools
interactively during development.

The new --log-stdout option in all three commands enables logging to
stdout in addition to the traditional log files.

The implementation recycles the existing init_log_stdout() (not used
before) and gives it the slightly different meaning of "also log to
stdout".

Reviewed before here: https://github.com/clearlinux/swupd-server/pull/34#discussion_r84761155