### PR TITLE
download required files via HTTP on demand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: c
 # - bsdiff 1.* is the Clear Linux OS fork
 before_install:
         - sudo apt-get -qq update
-        - sudo apt-get install -y libmagic-dev
+        - sudo apt-get install -y libmagic-dev libcurl4-nss-dev libarchive-dev libattr1-dev
 
 install:
         - wget https://github.com/libcheck/check/releases/download/0.11.0/check-0.11.0.tar.gz

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ swupd_create_update_SOURCES = \
 	src/helpers.c \
 	src/heuristics.c \
 	src/log.c \
+	src/in_memory_archive.c \
 	src/manifest.c \
 	src/pack.c \
 	src/rename.c \
@@ -54,6 +55,7 @@ swupd_make_fullfiles_SOURCES = \
 	src/globals.c \
 	src/groups.c \
 	src/helpers.c \
+	src/in_memory_archive.c \
 	src/log.c \
 	src/make_fullfiles.c \
 	src/manifest.c \
@@ -62,12 +64,13 @@ swupd_make_fullfiles_SOURCES = \
 	src/stats.c \
 	src/xattrs.c
 
-AM_CPPFLAGS = $(glib_CFLAGS) -I$(top_srcdir)/include
+AM_CPPFLAGS = $(glib_CFLAGS) $(libarchive_CFLAGS) -I$(top_srcdir)/include
 
 swupd_create_update_LDADD = \
 	$(glib_LIBS) \
 	$(zlib_LIBS) \
 	$(openssl_LIBS) \
+	$(libarchive_LIBS) \
 	$(bsdiff_LIBS)
 
 swupd_make_pack_LDADD = \
@@ -80,6 +83,7 @@ swupd_make_fullfiles_LDADD = \
 	$(glib_LIBS) \
 	$(zlib_LIBS) \
 	$(openssl_LIBS) \
+	$(libarchive_LIBS) \
 	$(bsdiff_LIBS)
 
 if ENABLE_LZMA

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,7 @@ swupd_create_update_SOURCES = \
 	src/chroot.c \
 	src/config.c \
 	src/create_update.c \
+	src/curl_helper.c \
 	src/delta.c \
 	src/fullfiles.c \
 	src/globals.c \
@@ -35,6 +36,7 @@ swupd_create_update_SOURCES = \
 swupd_make_pack_SOURCES = \
 	src/analyze_fs.c \
 	src/config.c \
+	src/curl_helper.c \
 	src/delta.c \
 	src/globals.c \
 	src/groups.c \
@@ -50,6 +52,7 @@ swupd_make_pack_SOURCES = \
 swupd_make_fullfiles_SOURCES = \
 	src/analyze_fs.c \
 	src/config.c \
+	src/curl_helper.c \
 	src/delta.c \
 	src/fullfiles.c \
 	src/globals.c \
@@ -64,10 +67,12 @@ swupd_make_fullfiles_SOURCES = \
 	src/stats.c \
 	src/xattrs.c
 
-AM_CPPFLAGS = $(glib_CFLAGS) $(libarchive_CFLAGS) -I$(top_srcdir)/include
+AM_CPPFLAGS = $(glib_CFLAGS) $(libarchive_CFLAGS) $(libcurl_CFLAGS) -I$(top_srcdir)/include
 
 swupd_create_update_LDADD = \
 	$(glib_LIBS) \
+        $(libcurl_LIBS) \
+	$(libarchive_LIBS) \
 	$(zlib_LIBS) \
 	$(openssl_LIBS) \
 	$(libarchive_LIBS) \
@@ -75,15 +80,18 @@ swupd_create_update_LDADD = \
 
 swupd_make_pack_LDADD = \
 	$(glib_LIBS) \
+        $(libcurl_LIBS) \
+	$(libarchive_LIBS) \
 	$(zlib_LIBS) \
 	$(openssl_LIBS) \
 	$(bsdiff_LIBS)
 
 swupd_make_fullfiles_LDADD = \
 	$(glib_LIBS) \
+        $(libcurl_LIBS) \
+	$(libarchive_LIBS) \
 	$(zlib_LIBS) \
 	$(openssl_LIBS) \
-	$(libarchive_LIBS) \
 	$(bsdiff_LIBS)
 
 if ENABLE_LZMA

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,7 @@ AC_ARG_ENABLE(
 		AC_DEFINE([SWUPD_WITH_BSDTAR], 0, [Use default tar command])),
 	AC_DEFINE([SWUPD_WITH_BSDTAR], 0, [Use default tar command])
 )
+PKG_CHECK_MODULES([libarchive], [libarchive])
 
 AC_ARG_ENABLE(
   [tests],

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,7 @@ AC_ARG_ENABLE(
 	AC_DEFINE([SWUPD_WITH_BSDTAR], 0, [Use default tar command])
 )
 PKG_CHECK_MODULES([libarchive], [libarchive])
+PKG_CHECK_MODULES([libcurl], [libcurl])
 
 AC_ARG_ENABLE(
   [tests],

--- a/include/curl_helper.h
+++ b/include/curl_helper.h
@@ -1,0 +1,34 @@
+/*
+ *   Software Updater - server side
+ *
+ *      Copyright © 2017 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Patrick Ohly <patrick.ohly@intel.com>
+ *
+ */
+
+#ifndef __INCLUDE_GUARD_LIBCURL_HELPER_H
+#define __INCLUDE_GUARD_LIBCURL_HELPER_H
+
+void curl_helper_free();
+int curl_helper_unpack_tar(const char *url, const char *target_dir);
+
+enum {
+	CURL_HELPER_OKAY = 0,
+	CURL_HELPER_FAILURE
+};
+
+#endif /* __INCLUDE_GUARD_LIBCURL_HELPER_H */

--- a/include/libarchive_helper.h
+++ b/include/libarchive_helper.h
@@ -1,0 +1,42 @@
+/*
+ *   Software Updater - server side
+ *
+ *      Copyright © 2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Patrick Ohly <patrick.ohly@intel.com>
+ *
+ */
+
+#ifndef __INCLUDE_GUARD_LIBARCHIVE_HELPER_H
+#define __INCLUDE_GUARD_LIBARCHIVE_HELPER_H
+
+#include <archive.h>
+#include <stdint.h>
+
+/*
+ * Used by archive_write_open() callbacks to store the resulting archive in memory.
+ */
+struct in_memory_archive {
+	uint8_t *buffer;
+	size_t allocated;
+	size_t used;
+	/* If not 0, aborts writing when the used data would become larger than this. */
+	size_t maxsize;
+};
+
+ssize_t in_memory_write(struct archive *, void *client_data, const void *buffer, size_t length);
+
+#endif /* __INCLUDE_GUARD_LIBARCHIVE_HELPER_H */

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -248,6 +248,7 @@ extern void consolidate_submanifests(struct manifest *manifest);
 extern void populate_file_struct(struct file *file, char *filename);
 extern void download_exta_base_content(void);
 
+struct timeval;
 extern char *get_elapsed_time(struct timeval *t1, struct timeval *t2);
 extern void init_log(const char *prefix, const char *bundle, int start, int end);
 extern void init_log_stdout(void);

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -161,12 +161,14 @@ extern char *state_dir;
 extern char *packstage_dir;
 extern char *image_dir;
 extern char *staging_dir;
+extern char *content_url;
 
 extern bool init_globals(void);
 extern void free_globals(void);
 extern bool set_format(char *);
 extern void check_root(void);
 extern bool set_state_dir(char *);
+extern bool set_content_url(const char *);
 extern bool init_state_globals(void);
 extern void free_state_globals(void);
 

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -268,17 +268,10 @@ extern FILE *fopen_exclusive(const char *filename); /* no mode, opens for write 
 extern void dump_file_info(struct file *file);
 extern void string_or_die(char **strp, const char *fmt, ...);
 extern void print_elapsed_time(const char *step, struct timeval *previous_time, struct timeval *current_time);
-extern int system_argv_pipe(char *const lhscmd[], char *const rhscmd[]);
-extern int system_argv_pipe_fd(int lnewstdinfd, int lnewstderrfd, char *const lhscmd[],
-			       int rnewstdoutfd, int rnewstderrfd, char *const rhscmd[]);
-extern void pipe_monitor(int lnewstdinfd, int lnewstderrfd, char *const lhscmd[],
-			 int rnewstdoutfd, int rnewstderrfd, char *const rhscmd[]);
 extern int system_argv(char *const argv[]);
-extern int system_argv_fd(int newstdinfd, int newstdoutfd, int newstderrfd, char *const cmd[]);
-extern pid_t system_argv_fd_nowait(int newstdinfd, int newstdoutfd, int newstderrfd, int closefd, char *const cmd[]);
-extern void exec_cmd_fd(int newstdinfd, int newstdoutfd, int newstderrfd, int closefd, char *const cmd[]);
-extern void move_fd(int oldfd, int newfd);
-extern int wait_process_terminate(pid_t pid);
+extern int system_argv_fd(char *const argv[], int newstdin, int newstdout, int newstderr);
+extern int system_argv_pipe(char *const argvp1[], int stdinp1, int stderrp1,
+			    char *const argvp2[], int stdoutp2, int stderrp2);
 extern int num_threads(float scaling);
 extern bool file_is_debuginfo(const char *path);
 

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -261,7 +261,7 @@ extern void type_change_detection(struct manifest *manifest);
 extern void rename_detection(struct manifest *manifest);
 extern void link_renames(GList *newfiles, int to_version);
 extern void final_link(GList *files);
-extern void __create_delta(struct file *file, int from_version, char *from_hash);
+extern void __create_delta(struct file *file, int from_version, int to_version, char *from_hash);
 
 extern void account_delta_hit(void);
 extern void account_delta_miss(void);

--- a/src/curl_helper.c
+++ b/src/curl_helper.c
@@ -1,0 +1,425 @@
+/*
+ *   Software Updater - server side
+ *
+ *      Copyright © 2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Patrick Ohly <patrick.ohly@intel.com>
+ *
+ */
+
+#include <glib.h>
+#include <curl/curl.h>
+#include <archive.h>
+#include <archive_entry.h>
+#include <stdlib.h>
+
+#include "curl_helper.h"
+#include "swupd.h"
+
+static GOnce curl_helper_once = G_ONCE_INIT;
+static GThreadPool *curl_helper_pool;
+
+static void curl_helper_perform(gpointer data, gpointer user_data);
+
+static gpointer curl_helper_init_once(gpointer __unused__ unused)
+{
+	curl_global_init(CURL_GLOBAL_ALL);
+	/*
+	 * We allow creating as many additional threads as needed to
+	 * match the number of active curl_helper_unpack_tar() calls.
+	 * That way each call is guaranteed to make progress.
+	 * glib will allocate additional threads, even if the other
+	 * non-exclusive thread pools have a limit.
+	 */
+	curl_helper_pool = g_thread_pool_new(curl_helper_perform, NULL,
+					     -1, FALSE, NULL);
+
+	return 0;
+}
+
+/**
+ * Allocate and initialize global state for use of curl. Because curl
+ * might not be needed at all, this function may be called more than
+ * once and is guaranteed to be thread-safe.
+ */
+void curl_helper_init()
+{
+	g_once(&curl_helper_once, curl_helper_init_once, 0);
+}
+
+/**
+ * Free resources that might (or might not) have been allocated.
+ * Not thread-safe.
+ */
+void curl_helper_free()
+{
+	if (curl_helper_once.status == G_ONCE_STATUS_READY) {
+		curl_global_cleanup();
+		g_thread_pool_free(curl_helper_pool, false, false);
+		curl_helper_once.status = G_ONCE_STATUS_READY;
+	}
+}
+
+/** Used for buffering data between threads. */
+#define CURL_HELPER_TRANSFER_SIZE (1 * 1024 * 1024)
+
+struct curl_helper_transfer
+{
+	CURL *curl;
+
+	/* Protects the following struct members. */
+	GMutex mutex;
+	GCond cond;
+
+	/**
+	 * We do zero-copy by letting libarchive process directly the
+	 * buffer handed in by libcurl. It is debatable whether zero-copy
+	 * with higher overhead for context switching is more efficient
+	 * than double-buffering with more memcpy. Zero-copy is probably
+	 * a bit less code.
+	 *
+	 * The buffer is set while we have data ready to be processed.
+	 * Writing blocks in libcurl until the data is fully handled.
+	 */
+	const char *buffer;
+
+	/** Number of bytes in buffer. */
+	size_t available;
+
+	/** True while libarchive is working on the buffer. */
+	bool processing;
+
+	/** True while data is coming in. */
+	bool writing;
+
+	/** True while data is taken out. */
+	bool reading;
+
+	/** Result and message only valid when not writing anymore. */
+	CURLcode res;
+	char message[CURL_ERROR_SIZE];
+};
+
+struct curl_helper_transfer *
+curl_helper_transfer_new()
+{
+	struct curl_helper_transfer *transfer;
+
+	transfer = calloc(1, sizeof(*transfer));
+	g_mutex_init(&transfer->mutex);
+	g_cond_init(&transfer->cond);
+	transfer->writing = true;
+	transfer->reading = true;
+	return transfer;
+}
+
+static size_t
+curl_helper_transfer_write(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+	struct curl_helper_transfer *transfer = userdata;
+	size_t written;
+
+	g_mutex_lock(&transfer->mutex);
+	if (transfer->reading) {
+		static const char empty_buffer[1];
+		/*
+		 * Hand over new buffer and wait until reader is done
+		 * with it. We need a valid buffer pointer even when
+		 * no data was coming in from libcurl.
+		 */
+		transfer->buffer = ptr ? ptr : empty_buffer;
+		written = size * nmemb;
+		transfer->available = written;
+		g_cond_signal(&transfer->cond);
+		while (transfer->buffer) {
+			g_cond_wait(&transfer->cond, &transfer->mutex);
+		}
+	} else {
+		/* Error, reader is gone but we still have data. */
+		written = 0;
+	}
+	g_mutex_unlock(&transfer->mutex);
+	return written;
+}
+
+static ssize_t curl_helper_transfer_read(struct archive __unused__ *a, void *client_data, const void **buff)
+{
+	struct curl_helper_transfer *transfer = client_data;
+	ssize_t read;
+
+	g_mutex_lock(&transfer->mutex);
+	if (transfer->processing) {
+		/* Tell writer that we are done with the previous buffer. */
+		transfer->buffer = NULL;
+		transfer->processing = false;
+		g_cond_signal(&transfer->cond);
+	}
+
+	while (!transfer->buffer && transfer->writing) {
+		/* Wait for next buffer or end of writing. */
+		g_cond_wait(&transfer->cond, &transfer->mutex);
+	}
+
+	if (transfer->buffer) {
+		/* Process next chunk. */
+		*buff = transfer->buffer;
+		read = transfer->available;
+		transfer->processing = true;
+	} else if (transfer->res == CURLE_OK) {
+		/* Normal EOF. */
+		read = 0;
+	} else {
+		/* Signal error. */
+		read = -1;
+	}
+	g_mutex_unlock(&transfer->mutex);
+
+	return read;
+}
+
+static int curl_helper_transfer_close(struct archive __unused__ *a, void *client_data)
+{
+	struct curl_helper_transfer *transfer = client_data;
+
+	g_mutex_lock(&transfer->mutex);
+	if (transfer->processing) {
+		transfer->buffer = NULL;
+		transfer->processing = false;
+	}
+	transfer->reading = false;
+	g_cond_signal(&transfer->cond);
+	g_mutex_unlock(&transfer->mutex);
+
+	return ARCHIVE_OK;
+}
+
+static int curl_helper_copy_data(struct archive *ar, struct archive *aw)
+{
+	int r;
+	const void *buffer;
+	size_t size;
+	off_t offset;
+
+	for (;;) {
+		r = archive_read_data_block(ar, &buffer, &size, &offset);
+		if (r == ARCHIVE_EOF) {
+			return ARCHIVE_OK;
+		} else if (r != ARCHIVE_OK) {
+			LOG(NULL, "Error reading data from archive: %s", archive_error_string(ar));
+			return r;
+		}
+
+		r = archive_write_data_block(aw, buffer, size, offset);
+		if (r != ARCHIVE_OK) {
+			LOG(NULL, "Error writing data from archive: %s", archive_error_string(aw));
+			return r;
+		}
+	}
+}
+
+/**
+ * Retrieves the file identified by the url and directly unpacks
+ * the archive with libarchive inside the target directory.
+ * Thread-safe.
+ */
+int curl_helper_unpack_tar(const char *url, const char *target_dir)
+{
+	struct curl_helper_transfer *transfer = NULL;
+	int ret = CURL_HELPER_FAILURE;
+	const char *cainfo;
+	struct archive *a = NULL, *ext = NULL;
+	struct archive_entry *entry;
+	int r;
+	int flags;
+
+	curl_helper_init();
+
+	/*
+	 * Both libcurl and libarchive want to be in control. There's
+	 * no way how a single thread can get some data out of libcurl
+	 * (pull) and hand it over to libarchive (push) for further
+	 * processing: libcurl wants to push, and libarchive wants to
+	 * pull. To get around this, we put libcurl processing into a
+	 * helper thread which copies data into a buffer which gets
+	 * drained by the libarchive read callbacks.
+	 */
+	transfer = curl_helper_transfer_new();
+	transfer->curl = curl_easy_init();
+	if (!transfer->curl) {
+		goto error;
+	}
+	curl_easy_setopt(transfer->curl, CURLOPT_URL, url);
+	curl_easy_setopt(transfer->curl, CURLOPT_ERRORBUFFER, transfer->message);
+	curl_easy_setopt(transfer->curl, CURLOPT_WRITEFUNCTION, curl_helper_transfer_write);
+	curl_easy_setopt(transfer->curl, CURLOPT_WRITEDATA, transfer);
+	/*
+	 * Mirror the behavior of curl and check CURL_CA_BUNDLE.
+	 * This is relevant for builds under OpenEmbedded, where the
+	 * builtin default path becomes invalid when moving the
+	 * native binary from one build machine to another (YOCTO #9883),
+	 * but may also be useful for pointing swupd to a self-signed
+	 * certificate that isn't installed on the system.
+	 */
+	cainfo = getenv("CURL_CA_BUNDLE");
+	if (cainfo && cainfo[0]) {
+		curl_easy_setopt(transfer->curl, CURLOPT_CAINFO, cainfo);
+	}
+
+	a = archive_read_new();
+	if (!a) {
+		LOG(NULL, "Failed to allocate archive for reading.", "");
+		goto error;
+	}
+
+	/* Set which attributes we want to restore. */
+	flags = ARCHIVE_EXTRACT_TIME;
+	flags |= ARCHIVE_EXTRACT_PERM;
+	flags |= ARCHIVE_EXTRACT_OWNER;
+	flags |= ARCHIVE_EXTRACT_XATTR;
+
+	/* Set security flags. However, ultimately the server trusts
+	 * the content of the archive to be correct. */
+	flags |= ARCHIVE_EXTRACT_SECURE_SYMLINKS;
+	flags |= ARCHIVE_EXTRACT_SECURE_NODOTDOT;
+
+	/* Limit parsing to tar. */
+	r = archive_read_support_format_tar(a);
+	if (r != ARCHIVE_OK) {
+		LOG(NULL, "Could not initialize tar processing", "%s", archive_error_string(a));
+		goto error;
+	}
+
+	/* All compression methods. */
+	r = archive_read_support_filter_all(a);
+	if (r != ARCHIVE_OK) {
+		LOG(NULL, "Could not initialize decompression", "%s", archive_error_string(a));
+		goto error;
+	}
+
+	/* set up write */
+	ext = archive_write_disk_new();
+	if (!ext) {
+		LOG(NULL, "Failed to allocate archive for writing.", "");
+		goto error;
+	}
+
+	r = archive_write_disk_set_options(ext, flags);
+	if (r != ARCHIVE_OK) {
+		LOG(NULL, "Failed to set archive write options", "%s", archive_error_string(ext));
+		goto error;
+	}
+
+	r = archive_write_disk_set_standard_lookup(ext);
+	if (r != ARCHIVE_OK) {
+		LOG(NULL, "Failed to set archive write options", "%s", archive_error_string(ext));
+		goto error;
+	}
+
+	/* Start data transfer for real now. */
+	g_thread_pool_push(curl_helper_pool, transfer, NULL);
+	r = archive_read_open(a, transfer, NULL, curl_helper_transfer_read, curl_helper_transfer_close);
+	if (r != ARCHIVE_OK) {
+		LOG(NULL, "Failed to initialize archive reading", "%s", archive_error_string(a));
+		goto error;
+	}
+	for (;;) {
+		r = archive_read_next_header(a, &entry);
+		if (r == ARCHIVE_EOF) {
+			/* Reached end of archive without errors. */
+			ret = CURL_HELPER_OKAY;
+			break;
+		} else if (r != ARCHIVE_OK) {
+			LOG(NULL, "Error while looking for next archive entry", "%s", archive_error_string(a));
+			goto error_writing;
+		}
+
+		/* Set output directory. */
+		char *fullpath;
+		string_or_die(&fullpath, "%s/%s", target_dir, archive_entry_pathname(entry));
+		archive_entry_set_pathname(entry, fullpath);
+		free(fullpath);
+
+		/* Write archive header, if successful continue to copy data. */
+		r = archive_write_header(ext, entry);
+		if (r != ARCHIVE_OK) {
+			LOG(NULL, "Error creating archive entry", "%s", archive_error_string(ext));
+			goto error_writing;
+		}
+
+		if (archive_entry_size(entry) > 0) {
+			r = curl_helper_copy_data(a, ext);
+			if (r != ARCHIVE_OK) {
+				LOG(NULL, "Error copying archive data", "%s");
+				goto error_writing;
+			}
+		}
+
+		/* Flush pending file attribute changes. */
+		r = archive_write_finish_entry(ext);
+		if (r != ARCHIVE_OK) {
+			LOG(NULL, "Error closing archive entry", "%s", archive_error_string(ext));
+			goto error_writing;
+		}
+	}
+	r = archive_write_close(ext);
+	if (r != ARCHIVE_OK) {
+		LOG(NULL, "Error closing the write archive", "%s", archive_error_string(ext));
+		goto error_writing;
+	}
+
+ error_writing:
+	/* We started the data transfer, so now we must wait for the libcurl thread to stop writing. */
+	g_mutex_lock(&transfer->mutex);
+	if (transfer->processing) {
+		transfer->buffer = NULL;
+		transfer->processing = false;
+	}
+	transfer->reading = false;
+	g_cond_signal(&transfer->cond);
+	while (transfer->writing) {
+		g_cond_wait(&transfer->cond, &transfer->mutex);
+	}
+	g_mutex_unlock(&transfer->mutex);
+	if (transfer->res != CURLE_OK) {
+		LOG(NULL, "Archive download error", "%s", transfer->message);
+	}
+
+ error:
+	if (ext) {
+		archive_write_free(ext);
+	}
+	if (a) {
+		archive_read_free(a);
+	}
+	if (transfer) {
+		free(transfer);
+	}
+	return ret;
+}
+
+static void curl_helper_perform(gpointer data, gpointer __unused__ user_data)
+{
+	struct curl_helper_transfer *transfer = (struct curl_helper_transfer *)data;
+	CURLcode res;
+
+	res = curl_easy_perform(transfer->curl);
+
+	g_mutex_lock(&transfer->mutex);
+	transfer->res = res;
+	transfer->writing = false;
+	g_cond_signal(&transfer->cond);
+	g_mutex_unlock(&transfer->mutex);
+}

--- a/src/delta.c
+++ b/src/delta.c
@@ -35,7 +35,7 @@
 #include "swupd.h"
 #include "xattrs.h"
 
-void __create_delta(struct file *file, int from_version, char *from_hash)
+void __create_delta(struct file *file, int from_version, int to_version, char *from_hash)
 {
 	char *original = NULL, *newfile = NULL, *outfile = NULL, *dotfile = NULL, *testnewfile = NULL, *conf = NULL;
 	char *tmpdir = NULL;
@@ -59,7 +59,7 @@ void __create_delta(struct file *file, int from_version, char *from_hash)
 	}
 
 	conf = config_image_base();
-	string_or_die(&newfile, "%s/%i/full/%s", conf, file->last_change, file->filename);
+	string_or_die(&newfile, "%s/%i/full/%s", conf, to_version, file->filename);
 
 	string_or_die(&original, "%s/%i/full/%s", conf, from_version, file->peer->filename);
 

--- a/src/fullfiles.c
+++ b/src/fullfiles.c
@@ -22,6 +22,8 @@
  */
 
 #define _GNU_SOURCE
+#include <archive.h>
+#include <archive_entry.h>
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -33,24 +35,27 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/xattr.h>
 #include <unistd.h>
 
 #include "swupd.h"
+#include "libarchive_helper.h"
 
 /* output must be a file, which is a (compressed) tar file, of the file denoted by "file", without any of its
    directory paths etc etc */
 static void create_fullfile(struct file *file)
 {
-	char *origin;
+	char *origin = NULL;
 	char *tarname = NULL;
-	char *rename_source = NULL;
-	char *rename_target = NULL;
-	char *rename_tmpdir = NULL;
-	int ret;
 	struct stat sbuf;
 	char *empty, *indir, *outdir;
-	char *param1, *param2;
-	int stderrfd;
+	struct archive_entry *entry = NULL;
+	struct archive *from = NULL, *to = NULL;
+	struct in_memory_archive best = { .buffer = NULL };
+	struct in_memory_archive current = { .buffer = NULL };
+	uint8_t *file_content = NULL;
+	size_t file_size;
+	int fd = -1;
 
 	if (file->is_deleted) {
 		return; /* file got deleted -> by definition we cannot tar it up */
@@ -59,15 +64,17 @@ static void create_fullfile(struct file *file)
 	empty = config_empty_dir();
 	indir = config_image_base();
 	outdir = config_output_dir();
+	entry = archive_entry_new();
+	assert(entry);
+	from = archive_read_disk_new();
+	assert(from);
 
 	string_or_die(&tarname, "%s/%i/files/%s.tar", outdir, file->last_change, file->hash);
 	if (access(tarname, R_OK) == 0) {
 		/* output file already exists...done */
-		free(tarname);
+		goto done;
 		return;
 	}
-	free(tarname);
-	//printf("%s was missing\n", file->hash);
 
 	string_or_die(&origin, "%s/%i/full/%s", indir, file->last_change, file->filename);
 	if (lstat(origin, &sbuf) < 0) {
@@ -76,156 +83,197 @@ static void create_fullfile(struct file *file)
 		assert(0);
 	}
 
-	if (file->is_dir) { /* directories are easy */
-		char *tmp1, *tmp2, *dir, *base;
+	/* step 1: tar it with each compression type  */
+	typedef int (*filter_t)(struct archive *);
+	static const filter_t compression_filters[] = {
+		/*
+		 * Start with the compression method that is most likely (*) to produce
+		 * the best result. That will allow aborting creation of archives earlier
+		 * when they become larger than the currently smallest archive.
+		 *
+		 * (*) statistics for ostro-image-swupd:
+		 *     43682 LZMA
+		 *     13398 gzip
+		 *       844 bzip2
+		 */
+		archive_write_add_filter_lzma,
+		archive_write_add_filter_gzip,
+		archive_write_add_filter_bzip2,
+		/*
+		 * TODO (?): can archive_write_add_filter_none ever be better than compressing?
+		 */
+		NULL
+	};
+	file_size = S_ISREG(sbuf.st_mode) ? sbuf.st_size : 0;
 
-		tmp1 = strdup(origin);
-		assert(tmp1);
-		base = basename(tmp1);
-
-		tmp2 = strdup(origin);
-		assert(tmp2);
-		dir = dirname(tmp2);
-
-		string_or_die(&rename_tmpdir, "%s/XXXXXX", outdir);
-		if (!mkdtemp(rename_tmpdir)) {
-			LOG(NULL, "Failed to create temporary directory for %s move", origin);
+	archive_entry_copy_sourcepath(entry, origin);
+	if (archive_read_disk_entry_from_file(from, entry, -1, &sbuf)) {
+		LOG(NULL, "Getting directory attributes failed", "%s: %s",
+		    origin, archive_error_string(from));
+		assert(0);
+	}
+	archive_entry_copy_pathname(entry, file->hash);
+	if (file_size) {
+		file_content = malloc(file_size);
+		if (!file_content) {
+			LOG(NULL, "out of memory", "");
 			assert(0);
 		}
-
-		string_or_die(&param1, "--exclude=%s/?*", base);
-		string_or_die(&param2, "./%s", base);
-		char *const tarcfcmd[] = { TAR_COMMAND, "-C", dir, TAR_PERM_ATTR_ARGS_STRLIST, "-cf", "-", param1, param2, NULL };
-		char *const tarxfcmd[] = { TAR_COMMAND, "-C", rename_tmpdir, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", "-", NULL };
-
-		stderrfd = open("/dev/null", O_WRONLY);
-		if (stderrfd == -1) {
-			LOG(NULL, "Failed to open /dev/null", "");
+		fd = open(origin, O_RDONLY);
+		if (fd == -1) {
+			LOG(NULL, "Failed to open file", "%s: %s",
+			    origin, strerror(errno));
 			assert(0);
 		}
-		if (system_argv_pipe(tarcfcmd, -1, stderrfd, tarxfcmd, -1, stderrfd) != 0) {
-			assert(0);
-		}
-		free(param1);
-		free(param2);
-		close(stderrfd);
-
-		string_or_die(&rename_source, "%s/%s", rename_tmpdir, base);
-		string_or_die(&rename_target, "%s/%s", rename_tmpdir, file->hash);
-		if (rename(rename_source, rename_target)) {
-			LOG(NULL, "rename failed for %s to %s", rename_source, rename_target);
-			assert(0);
-		}
-		free(rename_source);
-
-		/* for a directory file, tar up simply with gzip */
-		string_or_die(&param1, "%s/%i/files/%s.tar", outdir, file->last_change, file->hash);
-		char *const tarcmd[] = { TAR_COMMAND, "-C", rename_tmpdir, TAR_PERM_ATTR_ARGS_STRLIST, "-zcf", param1, file->hash, NULL };
-
-		if (system_argv(tarcmd) != 0) {
-			assert(0);
-		}
-		free(param1);
-
-		if (rmdir(rename_target)) {
-			LOG(NULL, "rmdir failed for %s", rename_target);
-		}
-		free(rename_target);
-		if (rmdir(rename_tmpdir)) {
-			LOG(NULL, "rmdir failed for %s", rename_tmpdir);
-		}
-		free(rename_tmpdir);
-
-		free(tmp1);
-		free(tmp2);
-	} else { /* files are more complex */
-		char *gzfile = NULL, *bzfile = NULL, *xzfile = NULL;
-		char *tempfile;
-		uint64_t gz_size = LONG_MAX, bz_size = LONG_MAX, xz_size = LONG_MAX;
-
-		/* step 1: hardlink the guy to an empty directory with the hash as the filename */
-		string_or_die(&tempfile, "%s/%s", empty, file->hash);
-		if (link(origin, tempfile) < 0) {
-			LOG(NULL, "hardlink failed", "%s due to %s (%s -> %s)", file->filename, strerror(errno), origin, tempfile);
-			char *const argv[] = { "cp", "-a", origin, tempfile, NULL };
-			if (system_argv(argv) != 0) {
+		size_t done = 0;
+		while (done < file_size) {
+			ssize_t curr;
+			curr = read(fd, file_content + done, file_size - done);
+			if (curr == -1) {
+				LOG(NULL, "Failed to read from file", "%s: %s",
+				    origin, strerror(errno));
 				assert(0);
 			}
+			done += curr;
 		}
-
-		/* step 2a: tar it with each compression type  */
-		// lzma
-		string_or_die(&param1, "--directory=%s", empty);
-		string_or_die(&param2, "%s/%i/files/%s.tar.xz", outdir, file->last_change, file->hash);
-		char *const tarlzmacmd[] = { TAR_COMMAND, param1, TAR_PERM_ATTR_ARGS_STRLIST, "-Jcf", param2, file->hash, NULL };
-
-		if (system_argv(tarlzmacmd) != 0) {
-			assert(0);
-		}
-		free(param1);
-		free(param2);
-
-		// gzip
-		string_or_die(&param1, "--directory=%s", empty);
-		string_or_die(&param2, "%s/%i/files/%s.tar.gz", outdir, file->last_change, file->hash);
-		char *const targzipcmd[] = { TAR_COMMAND, param1, TAR_PERM_ATTR_ARGS_STRLIST, "-zcf", param2, file->hash, NULL };
-
-		if (system_argv(targzipcmd) != 0) {
-			assert(0);
-		}
-		free(param1);
-		free(param2);
-
-#ifdef SWUPD_WITH_BZIP2
-		string_or_die(&param1, "--directory=%s", empty);
-		string_or_die(&param2, "%s/%i/files/%s.tar.bz2", outdir, file->last_change, file->hash);
-		char *const tarbzip2cmd[] = { TAR_COMMAND, param1, TAR_PERM_ATTR_ARGS_STRLIST, "-jcf", param2, file->hash, NULL };
-
-		if (system_argv(tarbzip2cmd) != 0) {
-			assert(0);
-		}
-		free(param1);
-		free(param2);
-
-#endif
-
-		/* step 2b: pick the smallest of the three compression formats */
-		string_or_die(&gzfile, "%s/%i/files/%s.tar.gz", outdir, file->last_change, file->hash);
-		if (stat(gzfile, &sbuf) == 0) {
-			gz_size = sbuf.st_size;
-		}
-		string_or_die(&bzfile, "%s/%i/files/%s.tar.bz2", outdir, file->last_change, file->hash);
-		if (stat(bzfile, &sbuf) == 0) {
-			bz_size = sbuf.st_size;
-		}
-		string_or_die(&xzfile, "%s/%i/files/%s.tar.xz", outdir, file->last_change, file->hash);
-		if (stat(xzfile, &sbuf) == 0) {
-			xz_size = sbuf.st_size;
-		}
-		string_or_die(&tarname, "%s/%i/files/%s.tar", outdir, file->last_change, file->hash);
-		if (gz_size <= xz_size && gz_size <= bz_size) {
-			ret = rename(gzfile, tarname);
-		} else if (xz_size <= bz_size) {
-			ret = rename(xzfile, tarname);
-		} else {
-			ret = rename(bzfile, tarname);
-		}
-		if (ret != 0) {
-			LOG(file, "post-tar rename failed", "ret=%d", ret);
-		}
-		unlink(bzfile);
-		unlink(xzfile);
-		unlink(gzfile);
-		free(bzfile);
-		free(xzfile);
-		free(gzfile);
-		free(tarname);
-
-		/* step 3: remove the hardlink */
-		unlink(tempfile);
-		free(tempfile);
+		close(fd);
+		fd = -1;
 	}
 
+	for (int i = 0; compression_filters[i]; i++) {
+		/* Need to re-initialize the archive handle, it cannot be re-used. */
+		if (to) {
+			archive_write_free(to);
+		}
+		/*
+		 * Use the recommended restricted pax interchange
+		 * format. Numeric uid/gid values are stored in the archive
+		 * (no uid/gid lookup enabled) because symbolic names can lead
+		 * to a hash mismatch during unpacking when /etc/passwd or
+		 * /etc/group change during an update (see
+		 * https://github.com/clearlinux/swupd-client/issues/101).
+		 *
+		 * Filenames read from the file system are expected to be
+		 * valid according to the current locale. archive_write_header()
+		 * will warn about filenames that it cannot properly decode
+		 * and proceeds by writing the raw bytes, but we treat this an
+		 * error by not distinguishing between ARCHIVE_FATAL
+		 * and ARCHIVE_WARN.
+		 *
+		 * When we fail with "Can't translate" errors, make sure that
+		 * LANG and/or LC_ env variables are set.
+		 */
+		to = archive_write_new();
+		assert(to);
+		if (archive_write_set_format_pax_restricted(to)) {
+			LOG(NULL, "PAX format", "%s", archive_error_string(to));
+			assert(0);
+		}
+		do {
+			/* Try compression methods until we find one which is supported. */
+			if (!compression_filters[i](to)) {
+				break;
+			}
+		} while(compression_filters[++i]);
+		/*
+		 * Regardless of the block size below, never pad the
+		 * last block, it just makes the archive larger.
+		 */
+		if (archive_write_set_bytes_in_last_block(to, 1)) {
+			LOG(NULL, "Removing padding failed", "");
+			assert(0);
+		}
+		/*
+		 * Invoke in_memory_write() as often as possible and check each
+		 * time whether we are already larger than the currently best
+		 * algorithm.
+		 */
+		current.maxsize = best.used;
+		if (archive_write_set_bytes_per_block(to, 0)) {
+			LOG(NULL, "Removing blocking failed", "");
+			assert(0);
+		}
+		/*
+		 * We can make an educated guess how large the resulting archive will be.
+		 * Avoids realloc() calls when the file is big.
+		 */
+		if (!current.allocated) {
+			current.allocated = file_size + 4096;
+			current.buffer = malloc(current.allocated);
+		}
+		if (!current.buffer) {
+			LOG(NULL, "out of memory", "");
+			assert(0);
+		}
+		if (archive_write_open(to, &current, NULL, in_memory_write, NULL)) {
+			LOG(NULL, "Failed to create archive", "%s",
+			    archive_error_string(to));
+			assert(0);
+		}
+		if (archive_write_header(to, entry) ||
+		    (file_content && archive_write_data(to, file_content, file_size) != (ssize_t)file_size) ||
+		    archive_write_close(to)) {
+			if (current.maxsize && current.used >= current.maxsize) {
+				archive_write_free(to);
+				to = NULL;
+				continue;
+			}
+			LOG(NULL, "Failed to store file in archive", "%s: %s",
+			    origin, archive_error_string(to));
+			assert(0);
+		}
+		if (!best.used || current.used < best.used) {
+			free(best.buffer);
+			best = current;
+			memset(&current, 0, sizeof(current));
+		} else {
+			/* Simply re-use the buffer for the next iteration. */
+			current.used = 0;
+		}
+	}
+	if (!best.used) {
+		LOG(NULL, "creating archive failed with all compression methods", "");
+		assert(0);
+	}
+
+	/* step 2: write out to disk. Archives are immutable and thus read-only. */
+	fd = open(tarname, O_CREAT|O_WRONLY, S_IRUSR|S_IRGRP|S_IROTH);
+	if (fd <= 0) {
+		LOG(NULL, "Failed to create archive", "%s: %s",
+		    tarname, strerror(errno));
+		assert(0);
+	}
+	size_t done = 0;
+	while (done < best.used) {
+		ssize_t curr;
+		curr = write(fd, best.buffer + done, best.used - done);
+		if (curr == -1) {
+			LOG(NULL, "Failed to write archive", "%s: %s",
+			    tarname, strerror(errno));
+			assert(0);
+		}
+		done += curr;
+	}
+	if (close(fd)) {
+		LOG(NULL, "Failed to complete writing archive", "%s: %s",
+		    tarname, strerror(errno));
+		assert(0);
+	}
+	fd = -1;
+	free(best.buffer);
+	free(current.buffer);
+	free(file_content);
+
+ done:
+	if (fd >= 0) {
+		close(fd);
+	}
+	archive_read_free(from);
+	if (to) {
+		archive_write_free(to);
+	}
+	archive_entry_free(entry);
+	free(tarname);
 	free(indir);
 	free(outdir);
 	free(empty);

--- a/src/fullfiles.c
+++ b/src/fullfiles.c
@@ -50,6 +50,7 @@ static void create_fullfile(struct file *file)
 	struct stat sbuf;
 	char *empty, *indir, *outdir;
 	char *param1, *param2;
+	int stderrfd;
 
 	if (file->is_deleted) {
 		return; /* file got deleted -> by definition we cannot tar it up */
@@ -97,13 +98,17 @@ static void create_fullfile(struct file *file)
 		char *const tarcfcmd[] = { TAR_COMMAND, "-C", dir, TAR_PERM_ATTR_ARGS_STRLIST, "-cf", "-", param1, param2, NULL };
 		char *const tarxfcmd[] = { TAR_COMMAND, "-C", rename_tmpdir, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", "-", NULL };
 
-		int tarcmdresult = system_argv_pipe(tarcfcmd, tarxfcmd);
-		if (tarcmdresult != 0) {
-			LOG(NULL, "Tar command for copying directory full file failed with code %d", tarcmdresult);
+		stderrfd = open("/dev/null", O_WRONLY);
+		if (stderrfd == -1) {
+			LOG(NULL, "Failed to open /dev/null", "");
+			assert(0);
+		}
+		if (system_argv_pipe(tarcfcmd, -1, stderrfd, tarxfcmd, -1, stderrfd) != 0) {
 			assert(0);
 		}
 		free(param1);
 		free(param2);
+		close(stderrfd);
 
 		string_or_die(&rename_source, "%s/%s", rename_tmpdir, base);
 		string_or_die(&rename_target, "%s/%s", rename_tmpdir, file->hash);

--- a/src/globals.c
+++ b/src/globals.c
@@ -39,6 +39,7 @@ char *state_dir = NULL;
 char *packstage_dir = NULL;
 char *image_dir = NULL;
 char *staging_dir = NULL;
+char *content_url = NULL;
 
 bool set_format(char *userinput)
 {
@@ -74,6 +75,17 @@ bool set_state_dir(char *dir)
 
 	return true;
 }
+
+bool set_content_url(const char *url)
+{
+	if (content_url) {
+		free(content_url);
+	}
+	string_or_die(&content_url, "%s", url);
+
+	return true;
+}
+
 
 bool init_globals(void)
 {
@@ -122,4 +134,5 @@ void free_state_globals(void)
 	free(packstage_dir);
 	free(image_dir);
 	free(staging_dir);
+	free(content_url);
 }

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -149,117 +149,130 @@ void concat_str_array(char **output, char *const argv[])
 	}
 }
 
-int system_argv_pipe(char *const lhscmd[], char *const rhscmd[])
-{
-	return system_argv_pipe_fd(-1, -1, lhscmd, -1, -1, rhscmd);
-}
-
-int system_argv_pipe_fd(int lnewstdinfd, int lnewstderrfd, char *const lhscmd[],
-			int rnewstdoutfd, int rnewstderrfd, char *const rhscmd[])
-{
-	pid_t monitorpid = fork();
-	if (monitorpid == -1) {
-		LOG(NULL, "Failed to create child process to monitor pipe between", "command %s and command %s", lhscmd[0], rhscmd[0]);
-		return -1;
-	} else if (monitorpid == 0) {
-		pipe_monitor(lnewstdinfd, lnewstderrfd, lhscmd, rnewstdoutfd, rnewstderrfd, rhscmd);
-	}
-	return wait_process_terminate(monitorpid);
-}
-
-void pipe_monitor(int lnewstdinfd, int lnewstderrfd, char *const lhscmd[],
-		  int rnewstdoutfd, int rnewstderrfd, char *const rhscmd[])
-{
-	int pipefd[2];
-	if (pipe(pipefd) == -1) {
-		LOG(NULL, "Failed to create a pipe between", "command %s and command %s", lhscmd[0], rhscmd[0]);
-		assert(0);
-	}
-
-	pid_t lhspid = system_argv_fd_nowait(lnewstdinfd, pipefd[1], lnewstderrfd, pipefd[0], lhscmd);
-	pid_t rhspid = system_argv_fd_nowait(pipefd[0], rnewstdoutfd, rnewstderrfd, pipefd[1], rhscmd);
-
-	if (close(pipefd[1]) == -1) {
-		LOG(NULL, "Could not close write end of pipe file descriptor", "%d", pipefd[1]);
-		assert(0);
-	}
-	if (close(pipefd[0]) == -1) {
-		LOG(NULL, "Could not close read end of pipe file descriptor", "%d", pipefd[0]);
-		assert(0);
-	}
-
-	int lhsresult = wait_process_terminate(lhspid);
-	int rhsresult = wait_process_terminate(rhspid);
-	exit(rhsresult != EXIT_SUCCESS ? rhsresult : lhsresult);
-}
-
 int system_argv(char *const argv[])
 {
-	return system_argv_fd(-1, -1, -1, argv);
-}
+	int child_exit_status;
+	pid_t pid;
+	int status = -1;
 
-int system_argv_fd(int newstdinfd, int newstdoutfd, int newstderrfd, char *const cmd[])
-{
-	pid_t cmdpid = system_argv_fd_nowait(newstdinfd, newstdoutfd, newstderrfd, -1, cmd);
-	return wait_process_terminate(cmdpid);
-}
+	pid = fork();
 
-pid_t system_argv_fd_nowait(int newstdinfd, int newstdoutfd, int newstderrfd, int closefd, char *const cmd[])
-{
-	pid_t cmdpid = fork();
-	if (cmdpid == -1) {
-		LOG(NULL, "Failed to fork to execute command", "%s", cmd[0]);
+	if (pid == 0) { /* child */
+		execvp(*argv, argv);
+		LOG(NULL, "This line must not be reached", "");
 		assert(0);
-	} else if (cmdpid == 0) {
-		exec_cmd_fd(newstdinfd, newstdoutfd, newstderrfd, closefd, cmd);
-	}
-	return cmdpid;
-}
-
-void exec_cmd_fd(int newstdinfd, int newstdoutfd, int newstderrfd, int closefd, char *const cmd[])
-{
-	move_fd(newstdinfd, STDIN_FILENO);
-	move_fd(newstdoutfd, STDOUT_FILENO);
-	move_fd(newstderrfd, STDERR_FILENO);
-	if (closefd >= 0 && close(closefd) == -1) {
-		LOG(NULL, "Could not close file descriptor", "%d", closefd);
+	} else if (pid < 0) {
+		LOG(NULL, "Failed to fork a child process", "");
 		assert(0);
-	}
-	execvp(*cmd, cmd);
-	LOG(NULL, "Command", "%s failed", cmd[0]);
-	assert(0);
-}
-
-void move_fd(int oldfd, int newfd)
-{
-	if (oldfd < 0 || newfd < 0 || oldfd == newfd) {
-		return;
-	}
-	if (dup2(oldfd, newfd) == -1) {
-		LOG(NULL, "Could not create duplicate file descriptor", "%d from %d", newfd, oldfd);
-		assert(0);
-	}
-	if (close(oldfd) == -1) {
-		LOG(NULL, "Could not close file descriptor", "%d", oldfd);
-		assert(0);
-	}
-}
-
-int wait_process_terminate(pid_t pid)
-{
-	int status;
-	do {
-		if (waitpid(pid, &status, 0) == -1) {
-			LOG(NULL, "Failed to wait for PID", "%d", pid);
-			return -1;
-		}
-	} while (!WIFEXITED(status) && !WIFSIGNALED(status));
-	// Exit statuses fall in the range of [0, 255].  Make signal statuses fall in a non-overlapping range starting with 256.
-	if (WIFEXITED(status)) {
-		return WEXITSTATUS(status);
 	} else {
-		return 256 + WTERMSIG(status);
+		pid_t ws = waitpid(pid, &child_exit_status, 0);
+
+		if (ws == -1) {
+			LOG(NULL, "Failed to wait for child process", "");
+			assert(0);
+		}
+
+		if (WIFEXITED(child_exit_status)) {
+			status = WEXITSTATUS(child_exit_status);
+		} else {
+			LOG(NULL, "Child process didn't exit", "");
+			assert(0);
+		}
+
+		if (status != 0) {
+			char *cmdline = NULL;
+
+			concat_str_array(&cmdline, argv);
+			LOG(NULL, "Failed to run command:", "%s", cmdline);
+			free(cmdline);
+		}
 	}
+
+	return status;
+}
+
+int system_argv_fd(char *const argv[], int newstdin, int newstdout, int newstderr)
+{
+	int child_exit_status;
+	pid_t pid;
+	int status = -1;
+
+	pid = fork();
+
+	if (pid == 0) { /* child */
+		if (newstdin >= 0) {
+			if (dup2(newstdin, STDIN_FILENO) == -1) {
+				LOG(NULL, "Could not redirect stdin", "");
+				assert(0);
+			}
+			close(newstdin);
+		}
+		if (newstdout >= 0) {
+			if (dup2(newstdout, STDOUT_FILENO) == -1) {
+				LOG(NULL, "Could not redirect stdout", "");
+				assert(0);
+			}
+			close(newstdout);
+		}
+		if (newstderr >= 0) {
+			if (dup2(newstderr, STDERR_FILENO) == -1) {
+				LOG(NULL, "Could not redirect stderr", "");
+				assert(0);
+			}
+			close(newstderr);
+		}
+
+		execvp(*argv, argv);
+		LOG(NULL, "This line must not be reached", "");
+		assert(0);
+	} else if (pid < 0) {
+		LOG(NULL, "Failed to fork a child process", "");
+		assert(0);
+	} else {
+		pid_t ws = waitpid(pid, &child_exit_status, 0);
+
+		if (ws == -1) {
+			LOG(NULL, "Failed to wait for child process", "");
+			assert(0);
+		}
+
+		if (WIFEXITED(child_exit_status)) {
+			status = WEXITSTATUS(child_exit_status);
+		} else {
+			LOG(NULL, "Child process didn't exit", "");
+			assert(0);
+		}
+
+		if (status != 0) {
+			char *cmdline = NULL;
+
+			concat_str_array(&cmdline, argv);
+			LOG(NULL, "Failed to run command:", "%s", cmdline);
+			free(cmdline);
+		}
+	}
+
+	return status;
+}
+
+int system_argv_pipe(char *const argvp1[], int stdinp1, int stderrp1,
+		     char *const argvp2[], int stdoutp2, int stderrp2)
+{
+	int statusp2;
+	int pipefd[2];
+
+	if (pipe(pipefd)) {
+		LOG(NULL, "Failed to create a pipe", "");
+		return -1;
+	}
+	system_argv_fd(argvp1, stdinp1, pipefd[1], stderrp1);
+	close(pipefd[1]);
+	statusp2 = system_argv_fd(argvp2, pipefd[0], stdoutp2, stderrp2);
+	close(pipefd[0]);
+
+	/* Returns the status of the failed process if any
+       If both processes failed returns the status of first one */
+	return statusp2;
 }
 
 void check_root(void)

--- a/src/in_memory_archive.c
+++ b/src/in_memory_archive.c
@@ -1,0 +1,67 @@
+/*
+ *   Software Updater - server side
+ *
+ *      Copyright © 2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Patrick Ohly <patrick.ohly@intel.com>
+ *
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include "libarchive_helper.h"
+
+ssize_t in_memory_write(struct archive *archive, void *client_data, const void *buffer, size_t length)
+{
+	struct in_memory_archive *in_memory = client_data;
+	void *newbuff;
+
+	if (in_memory->maxsize && in_memory->used + length >= in_memory->maxsize) {
+		archive_set_error(archive, EFBIG, "resulting archive would become larger than %lu",
+				  (unsigned long)in_memory->maxsize);
+		archive_write_fail(archive);
+		/*
+		 * Despite the error and archive_write_fail(), libarchive internally calls us
+		 * again and when we fail again, overwrites our error with something about
+		 * "Failed to clean up compressor". Therefore our caller needs to check for "used == maxsize"
+		 * to detect that we caused the failure.
+		 */
+		in_memory->used = in_memory->maxsize;
+		return -1;
+	}
+
+	if (in_memory->used + length > in_memory->allocated) {
+		/* Start with a small chunk, double in size to avoid too many reallocs. */
+		size_t new_size = in_memory->allocated ?
+			in_memory->allocated * 2 :
+			4096;
+		while (new_size < in_memory->used + length) {
+			new_size *= 2;
+		}
+		newbuff = realloc(in_memory->buffer, new_size);
+		if (!newbuff) {
+			archive_set_error(archive, ENOMEM, "failed to enlarge buffer");
+			return -1;
+		}
+		in_memory->buffer = newbuff;
+		in_memory->allocated = new_size;
+	}
+
+	memcpy(in_memory->buffer + in_memory->used, buffer, length);
+	in_memory->used += length;
+	return length;
+}

--- a/src/in_memory_archive.c
+++ b/src/in_memory_archive.c
@@ -22,6 +22,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "libarchive_helper.h"
 

--- a/src/make_packs.c
+++ b/src/make_packs.c
@@ -47,6 +47,7 @@ static const struct option prog_opts[] = {
 	{ "help", no_argument, 0, 'h' },
 	{ "log-stdout", no_argument, 0, 'l' },
 	{ "statedir", required_argument, 0, 'S' },
+	{ "content-url", required_argument, 0, 'u' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -58,6 +59,7 @@ static void usage(const char *name)
 	printf("   -h, --help              Show help options\n");
 	printf("   -l, --log-stdout        Write log messages also to stdout\n");
 	printf("   -S, --statedir          Optional directory to use for state [ default:=%s ]\n", SWUPD_SERVER_STATE_DIR);
+	printf("   -u, --content-url       Base URL of the update repo (optional, used to retrieve missing files on demand");
 	printf("\n");
 }
 
@@ -77,6 +79,12 @@ static bool parse_options(int argc, char **argv)
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
 				printf("Invalid --statedir argument ''%s'\n\n", optarg);
+				return false;
+			}
+			break;
+		case 'u':
+			if (!optarg || !set_content_url(optarg)) {
+				printf("Invalid --content-url argument ''%s''\n\n", optarg);
 				return false;
 			}
 			break;

--- a/src/make_packs.c
+++ b/src/make_packs.c
@@ -35,6 +35,7 @@
 #include <unistd.h>
 
 #include "swupd.h"
+#include "curl_helper.h"
 
 static void banner(void)
 {
@@ -164,5 +165,6 @@ int main(int argc, char **argv)
 	       module, start_version, end_version);
 
 	free_state_globals();
+	curl_helper_free();
 	return exit_status;
 }

--- a/src/pack.c
+++ b/src/pack.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 
 #include "swupd.h"
+#include "xattrs.h"
 
 static void empty_pack_stage(int full, int from_version, int to_version, char *module)
 {
@@ -148,11 +149,44 @@ static void prepare_pack(struct packdata *pack)
 	link_renames(pack->end_manifest->files, pack->to);
 }
 
+static int stage_entry(struct file *file,
+		       const char *fullfrom, const char *fullto,
+		       const char *packname)
+{
+	int ret;
+
+	if (file->is_dir) {
+		/* Replicate directory. */
+		struct stat st;
+		if ((stat(fullfrom, &st) ||
+		     mkdir(fullto, 0) ||
+		     chmod(fullto, st.st_mode) ||
+		     chown(fullto, st.st_uid, st.st_gid) ||
+		     (xattrs_copy(fullfrom, fullto), false)) &&
+		    errno != EEXIST) {
+			LOG(NULL, "Failure to replicate dir for pack", "%s: %s to %s (%s) %i", packname, fullfrom, fullto, strerror(errno), errno);
+			rmdir(fullto);
+			ret = -1;
+		} else {
+			ret = 0;
+		}
+	} else {
+		ret = link(fullfrom, fullto);
+		if (ret && errno == EEXIST) {
+			ret = 0;
+		} else if (ret) {
+			LOG(NULL, "Failure to link for pack", "%s: %s to %s (%s) %i", packname, fullfrom, fullto, strerror(errno), errno);
+		}
+	}
+
+	return ret;
+}
+
+
 static void make_pack_full_files(struct packdata *pack)
 {
 	GList *item;
 	struct file *file;
-	int ret;
 
 	LOG(NULL, "starting pack full file creation", "%s: %d to %d",
 	    pack->module, pack->from, pack->to);
@@ -167,43 +201,17 @@ static void make_pack_full_files(struct packdata *pack)
 		    !file->is_deleted &&  /* no full-files for deletes */
 		    !file->is_ghosted &&  /* no full-files for ghosts */
 		    !file->rename_peer) { /* no full-files for renames */
-			char *from, *to;
 			char *fullfrom, *fullto;
 
-			/* hardlink each file that is in <end> but not in <X> */
-			string_or_die(&fullfrom, "%s/%i/full/%s", image_dir, file->last_change, file->filename);
+			/* stage each entry that is in <end> but not in <X> */
+			string_or_die(&fullfrom, "%s/%i/full/%s", image_dir, pack->to, file->filename);
 			string_or_die(&fullto, "%s/%s/%i_to_%i/staged/%s", packstage_dir,
 				      pack->module, pack->from, pack->to, file->hash);
-			string_or_die(&from, "%s/%i/files/%s.tar", staging_dir, file->last_change, file->hash);
-			string_or_die(&to, "%s/%s/%i_to_%i/staged/%s.tar", packstage_dir,
-				      pack->module, pack->from, pack->to, file->hash);
 
-			ret = -1;
-			errno = 0;
-
-			/* Prefer to hardlink uncompressed files (excluding
-			 * directories) first, and fall back to the compressed
-			 * versions if the hardlink fails.
-			 */
-			if (!file->is_dir) {
-				ret = link(fullfrom, fullto);
-				if (ret && errno != EEXIST) {
-					LOG(NULL, "Failure to link for fullfile pack", "%s to %s (%s) %i", fullfrom, fullto, strerror(errno), errno);
-				}
-			}
-			if (ret) {
-				ret = link(from, to);
-				if (ret && errno != EEXIST) {
-					LOG(NULL, "Failure to link for fullfile pack", "%s to %s (%s) %i", from, to, strerror(errno), errno);
-				}
-			}
-
-			if (ret == 0) {
+			if (!stage_entry(file, fullfrom, fullto, "fullfile")) {
 				pack->fullcount++;
 			}
 
-			free(from);
-			free(to);
 			free(fullfrom);
 			free(fullto);
 		}
@@ -278,17 +286,18 @@ static GList *consolidate_packs_delta_files(GList *files, struct packdata *pack)
 	return files;
 }
 
-static void create_delta(gpointer data, __unused__ gpointer user_data)
+static void create_delta(gpointer data, gpointer user_data)
 {
 	struct file *file = data;
+	int *to_version = user_data;
 
 	/* if the file was not found in the from version, skip delta creation */
 	if (file->peer) {
-		__create_delta(file, file->peer->last_change, file->peer->hash);
+		__create_delta(file, file->peer->last_change, *to_version, file->peer->hash);
 	}
 }
 
-static void make_pack_deltas(GList *files)
+static void make_pack_deltas(GList *files, int to_version)
 {
 	GThreadPool *threadpool;
 	GList *item;
@@ -298,7 +307,7 @@ static void make_pack_deltas(GList *files)
 	int numthreads = num_threads(1.0);
 
 	LOG(NULL, "pack deltas threadpool", "%d threads", numthreads);
-	threadpool = g_thread_pool_new(create_delta, NULL,
+	threadpool = g_thread_pool_new(create_delta, &to_version,
 				       numthreads, FALSE, NULL);
 
 	item = g_list_first(files);
@@ -355,7 +364,7 @@ static int make_final_pack(struct packdata *pack)
 			      file->last_change, file->hash);
 		string_or_die(&tarto, "%s/%s/%i_to_%i/staged/%s.tar", packstage_dir,
 			      pack->module, pack->from, pack->to, file->hash);
-		string_or_die(&fullfrom, "%s/%i/full/%s", image_dir, file->last_change, file->filename);
+		string_or_die(&fullfrom, "%s/%i/full/%s", image_dir, pack->to, file->filename);
 		string_or_die(&fullto, "%s/%s/%i_to_%i/staged/%s", packstage_dir,
 			      pack->module, pack->from, pack->to, file->hash);
 
@@ -389,27 +398,7 @@ static int make_final_pack(struct packdata *pack)
 				}
 			}
 		} else {
-			ret = -1;
-			errno = 0;
-
-			/* Prefer to hardlink uncompressed files (excluding
-			 * directories) first, and fall back to the compressed
-			 * versions if the hardlink fails.
-			 */
-			if (!file->is_dir) {
-				ret = link(fullfrom, fullto);
-				if (ret && errno != EEXIST) {
-					LOG(NULL, "Failure to link for final pack", "%s to %s (%s) %i\n", fullfrom, fullto, strerror(errno), errno);
-				}
-			}
-
-			if (ret) {
-				ret = link(tarfrom, tarto);
-				if (ret && errno != EEXIST) {
-					LOG(NULL, "Failure to link for final pack", "%s to %s (%s) %i\n", tarfrom, tarto, strerror(errno), errno);
-				}
-			}
-
+			ret = stage_entry(file, fullfrom, fullto, "final");
 			if (ret == 0) {
 				pack->fullcount++;
 			}
@@ -520,7 +509,7 @@ int make_pack(struct packdata *pack)
 
 	/* step 2: consolidate delta list & create all delta files*/
 	delta_list = consolidate_packs_delta_files(delta_list, pack);
-	make_pack_deltas(delta_list);
+	make_pack_deltas(delta_list, pack->to);
 	g_list_free(delta_list);
 
 	/* step 3: complete pack creation */


### PR DESCRIPTION
At the moment, the assumption is that swupd-server has normal file
access to the previous build artifacts. That's not true for the Ostro
CI or Ostro developers doing local builds on their workstations.

This problem gets solved in two places:
- meta-swupd downloads Manifests files before invoking swupd-server
- these patches minimize the usage of old build artifacts (which is
  possible also for normal builds) and add downloading via HTTP as
  fallback

This relies only on the fullfiles that already gets published. bsdtar
is always used for unpacking because it can detect the compression
method without an intermediate file.

Because calling external programs is problematic (see commit 557fb49), the initial proof-of-concept with
external curl+bsdtar later gets replaced with an implementation
using libcurl+libarchive directly. That relies on PR #48, which therefore gets
included here.

