### PR TITLE
use libarchive directly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ swupd_create_update_SOURCES = \
 	src/helpers.c \
 	src/heuristics.c \
 	src/log.c \
+	src/in_memory_archive.c \
 	src/manifest.c \
 	src/pack.c \
 	src/rename.c \
@@ -56,6 +57,7 @@ swupd_make_fullfiles_SOURCES = \
 	src/globals.c \
 	src/groups.c \
 	src/helpers.c \
+	src/in_memory_archive.c \
 	src/log.c \
 	src/make_fullfiles.c \
 	src/manifest.c \
@@ -65,12 +67,13 @@ swupd_make_fullfiles_SOURCES = \
 	src/stats.c \
 	src/xattrs.c
 
-AM_CPPFLAGS = $(glib_CFLAGS) -I$(top_srcdir)/include
+AM_CPPFLAGS = $(glib_CFLAGS) $(libarchive_CFLAGS) -I$(top_srcdir)/include
 
 swupd_create_update_LDADD = \
 	$(glib_LIBS) \
 	$(zlib_LIBS) \
 	$(openssl_LIBS) \
+	$(libarchive_LIBS) \
 	$(bsdiff_LIBS)
 
 swupd_make_pack_LDADD = \
@@ -83,6 +86,7 @@ swupd_make_fullfiles_LDADD = \
 	$(glib_LIBS) \
 	$(zlib_LIBS) \
 	$(openssl_LIBS) \
+	$(libarchive_LIBS) \
 	$(bsdiff_LIBS)
 
 if ENABLE_LZMA

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,7 @@ AC_ARG_ENABLE(
 		AC_DEFINE([SWUPD_WITH_BSDTAR], 0, [Use default tar command])),
 	AC_DEFINE([SWUPD_WITH_BSDTAR], 0, [Use default tar command])
 )
+PKG_CHECK_MODULES([libarchive], [libarchive])
 
 AC_ARG_ENABLE(
   [tests],

--- a/include/libarchive_helper.h
+++ b/include/libarchive_helper.h
@@ -1,0 +1,42 @@
+/*
+ *   Software Updater - server side
+ *
+ *      Copyright © 2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Patrick Ohly <patrick.ohly@intel.com>
+ *
+ */
+
+#ifndef __INCLUDE_GUARD_LIBARCHIVE_HELPER_H
+#define __INCLUDE_GUARD_LIBARCHIVE_HELPER_H
+
+#include <archive.h>
+#include <stdint.h>
+
+/*
+ * Used by archive_write_open() callbacks to store the resulting archive in memory.
+ */
+struct in_memory_archive {
+	uint8_t *buffer;
+	size_t allocated;
+	size_t used;
+	/* If not 0, aborts writing when the used data would become larger than this. */
+	size_t maxsize;
+};
+
+ssize_t in_memory_write(struct archive *, void *client_data, const void *buffer, size_t length);
+
+#endif /* __INCLUDE_GUARD_LIBARCHIVE_HELPER_H */

--- a/src/create_update.c
+++ b/src/create_update.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <glib.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -258,6 +259,11 @@ int main(int argc, char **argv)
 
 	/* keep valgrind working well */
 	setenv("G_SLICE", "always-malloc", 0);
+
+	if (!setlocale(LC_ALL, "")) {
+		fprintf(stderr, "%s: setlocale() failed\n", argv[0]);
+		return EXIT_FAILURE;
+	}
 
 	if (!parse_options(argc, argv)) {
 		free_globals();

--- a/src/in_memory_archive.c
+++ b/src/in_memory_archive.c
@@ -1,0 +1,67 @@
+/*
+ *   Software Updater - server side
+ *
+ *      Copyright © 2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Patrick Ohly <patrick.ohly@intel.com>
+ *
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include "libarchive_helper.h"
+
+ssize_t in_memory_write(struct archive *archive, void *client_data, const void *buffer, size_t length)
+{
+	struct in_memory_archive *in_memory = client_data;
+	void *newbuff;
+
+	if (in_memory->maxsize && in_memory->used + length >= in_memory->maxsize) {
+		archive_set_error(archive, EFBIG, "resulting archive would become larger than %lu",
+				  (unsigned long)in_memory->maxsize);
+		archive_write_fail(archive);
+		/*
+		 * Despite the error and archive_write_fail(), libarchive internally calls us
+		 * again and when we fail again, overwrites our error with something about
+		 * "Failed to clean up compressor". Therefore our caller needs to check for "used == maxsize"
+		 * to detect that we caused the failure.
+		 */
+		in_memory->used = in_memory->maxsize;
+		return -1;
+	}
+
+	if (in_memory->used + length > in_memory->allocated) {
+		/* Start with a small chunk, double in size to avoid too many reallocs. */
+		size_t new_size = in_memory->allocated ?
+			in_memory->allocated * 2 :
+			4096;
+		while (new_size < in_memory->used + length) {
+			new_size *= 2;
+		}
+		newbuff = realloc(in_memory->buffer, new_size);
+		if (!newbuff) {
+			archive_set_error(archive, ENOMEM, "failed to enlarge buffer");
+			return -1;
+		}
+		in_memory->buffer = newbuff;
+		in_memory->allocated = new_size;
+	}
+
+	memcpy(in_memory->buffer + in_memory->used, buffer, length);
+	in_memory->used += length;
+	return length;
+}

--- a/src/make_fullfiles.c
+++ b/src/make_fullfiles.c
@@ -23,6 +23,7 @@
 #define _GNU_SOURCE
 #include <assert.h>
 #include <getopt.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -87,6 +88,11 @@ int main(int argc, char **argv)
 
 	/* keep valgrind working well */
 	setenv("G_SLICE", "always-malloc", 0);
+
+	if (!setlocale(LC_ALL, "")) {
+		fprintf(stderr, "%s: setlocale() failed\n", argv[0]);
+		return EXIT_FAILURE;
+	}
 
 	if (!parse_options(argc, argv)) {
 		free_state_globals();

--- a/src/make_packs.c
+++ b/src/make_packs.c
@@ -27,6 +27,7 @@
 #include <getopt.h>
 #include <getopt.h>
 #include <glib.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -100,6 +101,11 @@ int main(int argc, char **argv)
 	struct packdata *pack;
 	int exit_status = EXIT_FAILURE;
 	char *file_path = NULL;
+
+	if (!setlocale(LC_ALL, "")) {
+		fprintf(stderr, "%s: setlocale() failed\n", argv[0]);
+		return EXIT_FAILURE;
+	}
 
 	if (!parse_options(argc, argv)) {
 		free_state_globals();


### PR DESCRIPTION
This may or may not work without changes for Clear: it might work that
GNU tar can unpack fullfiles created this way, but long filenames
might be problematic. xattrs are known to be problematic (not used
outside of Ostro?).

If this change turns out to be problematic, then it could be merged by
switching to bsdtar in client and server also in Clear and introducing
a format change. Once that's done, support for GNU tar and the
necessary ifdefs can be removed, followed by converting more code to
calling libarchive directly.

For example:
* creating the pack archives can be done entirely without the temporary
  packstage directories
* downloading on demand could be implemented without external curl/bsdtar,
  which is what the code in PR #47 currently uses