### PR TITLE
build: add 'compliant' target for fixing code style issues

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -134,6 +134,27 @@ endif
 distclean-local:
 	rm -rf aclocal.m4 autogen.sh autom4te.cache config.h.in config.h.in~ configure depcomp install-sh Makefile.in missing compile
 
+compliant:
+	@git diff --quiet --exit-code include src; ret=$$?; \
+	if [ $$ret -eq 1 ]; then \
+		echo "Error: can only check code style when include/ and src/ are clean."; \
+		echo "Stash or commit your changes and try again."; \
+		exit $$ret; \
+	elif [ $$ret -gt 1 ]; then \
+		exit $$ret; \
+	fi; \
+	clang-format -i -style=file include/*.h src/*.c; ret=$$?; \
+	if [ $$ret -ne 0 ]; then \
+		exit $$ret; \
+	fi; \
+	git diff --quiet --exit-code include src; ret=$$?; \
+	if [ $$ret -eq 1 ]; then \
+		echo "Code style issues found. Run 'git diff' to view issues."; \
+	elif [ $$ret -eq 0 ]; then \
+		echo "No code style issues found."; \
+	fi; \
+	exit $$ret
+
 release:
 	@git rev-parse v$(PACKAGE_VERSION) &> /dev/null; \
 	if [ "$$?" -eq 0 ]; then \


### PR DESCRIPTION
To simplify the discovery of C code style issues and enforce the rules
specified in .clang-format, I've added a new 'compliant' target for
running the appropriate clang-format command.

In case code style issues are found, source files are modified in place,
and the resulting diff can be viewed. The exit code in this case will be
1, so make will exit with an error. This helps to automate testing for
code style issues.