### PR TITLE
Only create deltas between two regular files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -109,14 +109,14 @@ TESTS = $(dist_check_SCRIPTS)
 dist_check_SCRIPTS = \
 	test/functional/basic/test.bats \
 	test/functional/delete-no-version-bump/test.bats \
-	test/functional/include-version-bump/test.bats \
-	test/functional/update/test.bats \
-	test/functional/fullfiles/test.bats \
-	test/functional/pack/test.bats \
-	test/functional/full-run/test.bats \
-	test/functional/full-run-delta/test.bats \
 	test/functional/file-name-blacklisted/test.bats \
-	test/functional/state-file/test.bats
+	test/functional/full-run-delta/test.bats \
+	test/functional/full-run/test.bats \
+	test/functional/fullfiles/test.bats \
+	test/functional/include-version-bump/test.bats \
+	test/functional/pack/test.bats \
+	test/functional/state-file/test.bats \
+	test/functional/update/test.bats
 endif
 
 if COVERAGE

--- a/Makefile.am
+++ b/Makefile.am
@@ -114,6 +114,7 @@ dist_check_SCRIPTS = \
 	test/functional/full-run/test.bats \
 	test/functional/fullfiles/test.bats \
 	test/functional/include-version-bump/test.bats \
+	test/functional/no-delta/test.bats \
 	test/functional/pack/test.bats \
 	test/functional/state-file/test.bats \
 	test/functional/update/test.bats

--- a/src/delta.c
+++ b/src/delta.c
@@ -40,8 +40,8 @@ void __create_delta(struct file *file, int from_version, char *from_hash)
 	char *original, *newfile, *outfile, *dotfile, *testnewfile, *conf;
 	int ret;
 
-	if (file->is_link) {
-		return;
+	if (!file->is_file || !file->peer->is_file) {
+		return; /* only support deltas between two regular files right now */
 	}
 
 	if (file->is_deleted) {

--- a/test/functional/full-run-delta/test.bats
+++ b/test/functional/full-run-delta/test.bats
@@ -21,7 +21,7 @@ setup() {
   track_bundle 20 included-two
   track_bundle 20 included-nested
 
-  gen_file_to_delta 10 4096 20 4 test-bundle
+  gen_file_to_delta 10 4096 20 4 test-bundle randomfile
 
   gen_file_plain 10 test-bundle foo
   gen_file_plain 10 test-bundle foobarbaz

--- a/test/functional/no-delta/test.bats
+++ b/test/functional/no-delta/test.bats
@@ -25,6 +25,13 @@ setup() {
   gen_file_to_delta 10 4096 20 4 os-core testfile2
   copy_file 10 os-core testfile2 10 os-core testsym2
   gen_symlink_to_file 20 os-core testsym2 testfile2
+
+  # symlink change + symlink target change; delta should be created for
+  # testfile3, but not for the dereferenced testsym3
+  gen_file_to_delta 10 4096 20 4 os-core testfile3
+  copy_file 20 os-core testfile3 20 os-core testfile4
+  gen_symlink_to_file 10 os-core testsym3 testfile3
+  gen_symlink_to_file 20 os-core testsym3 testfile4
 }
 
 @test "no deltas created for type changes or dereferenced symlinks" {
@@ -44,6 +51,10 @@ setup() {
   hash2=$(hash_for 20 os-core "/testfile2")
   [ -f $DIR/www/20/delta/10-20-$hash1-$hash2 ]
 
+  hash1=$(hash_for 10 os-core "/testfile3")
+  hash2=$(hash_for 20 os-core "/testfile3")
+  [ -f $DIR/www/20/delta/10-20-$hash1-$hash2 ]
+
   # deltas for symlink type changes should not be created
   hash1=$(hash_for 10 os-core "/testsym1")
   hash2=$(hash_for 20 os-core "/testsym1")
@@ -51,6 +62,10 @@ setup() {
 
   hash1=$(hash_for 10 os-core "/testsym2")
   hash2=$(hash_for 20 os-core "/testsym2")
+  [ ! -f $DIR/www/20/delta/10-20-$hash1-$hash2 ]
+
+  hash1=$(hash_for 10 os-core "/testsym3")
+  hash2=$(hash_for 20 os-core "/testsym3")
   [ ! -f $DIR/www/20/delta/10-20-$hash1-$hash2 ]
 }
 

--- a/test/functional/no-delta/test.bats
+++ b/test/functional/no-delta/test.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+# common functions
+load "../swupdlib"
+
+setup() {
+  clean_test_dir
+  init_test_dir
+
+  init_server_ini
+  set_latest_ver 0
+  init_groups_ini os-core
+
+  set_os_release 10 os-core
+  track_bundle 10 os-core
+  set_os_release 20 os-core
+  track_bundle 20 os-core
+
+  # symlink -> regular file type change (L -> F)
+  gen_file_to_delta 10 4096 20 4 os-core testfile1
+  gen_symlink_to_file 10 os-core testsym1 testfile1
+  copy_file 10 os-core testfile1 20 os-core testsym1
+
+  # regular file -> symlink type change (F -> L)
+  gen_file_to_delta 10 4096 20 4 os-core testfile2
+  copy_file 10 os-core testfile2 10 os-core testsym2
+  gen_symlink_to_file 20 os-core testsym2 testfile2
+}
+
+@test "no deltas created for type changes or dereferenced symlinks" {
+  sudo $CREATE_UPDATE --osversion 10 --statedir $DIR --format 3
+  set_latest_ver 10
+  sudo $CREATE_UPDATE --osversion 20 --statedir $DIR --format 3
+
+  # attempt to create some deltas
+  sudo $MAKE_PACK --statedir $DIR 10 20 os-core
+
+  # F -> F deltas should exist
+  hash1=$(hash_for 10 os-core "/testfile1")
+  hash2=$(hash_for 20 os-core "/testfile1")
+  [ -f $DIR/www/20/delta/10-20-$hash1-$hash2 ]
+
+  hash1=$(hash_for 10 os-core "/testfile2")
+  hash2=$(hash_for 20 os-core "/testfile2")
+  [ -f $DIR/www/20/delta/10-20-$hash1-$hash2 ]
+
+  # deltas for symlink type changes should not be created
+  hash1=$(hash_for 10 os-core "/testsym1")
+  hash2=$(hash_for 20 os-core "/testsym1")
+  [ ! -f $DIR/www/20/delta/10-20-$hash1-$hash2 ]
+
+  hash1=$(hash_for 10 os-core "/testsym2")
+  hash2=$(hash_for 20 os-core "/testsym2")
+  [ ! -f $DIR/www/20/delta/10-20-$hash1-$hash2 ]
+}
+
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -106,4 +106,35 @@ gen_file_plain_change() {
   echo "$ver $name" > $DIR/image/$ver/$bundle/"$name"
 }
 
+gen_symlink_to_file() {
+  local ver=$1
+  local bundle=$2
+  local symname="$3"
+  local filename="$4"
+
+  mkdir -p $DIR/image/$ver/$bundle/$(dirname "$symname")
+  ln -s "$filename" $DIR/image/$ver/$bundle/"$symname"
+}
+
+copy_file() {
+  local origver=$1
+  local origbundle=$2
+  local origname="$3"
+  local newver=$4
+  local newbundle=$5
+  local newname="$6"
+
+  mkdir -p $DIR/image/$newver/$newbundle/$(dirname "$newname")
+  cp -a $DIR/image/$origver/$origbundle/"$origname" $DIR/image/$newver/$newbundle/"$newname"
+}
+
+# Gets the hash for file NAME in BUNDLE manifest for VER
+hash_for() {
+  local ver=$1
+  local bundle=$2
+  local name="$3"
+
+  awk -F'\t' -v NAME="$name" 'NF == 4 && $4 == NAME { print $2 }' $DIR/www/$ver/Manifest.$bundle
+}
+
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -72,16 +72,17 @@ gen_file_to_delta() {
   local newver=$3
   local newbytes=$4
   local bundle=$5
+  local name=$6
 
   # create some random data for the original version
   mkdir -p $DIR/image/$origver/$bundle
-  dd if=/dev/urandom of=$DIR/image/$origver/$bundle/randomfile bs=1 count=$origsize
+  dd if=/dev/urandom of=$DIR/image/$origver/$bundle/$name bs=1 count=$origsize
 
   # append more random data to the end of the file in the new version
   TMP=$(mktemp foo.XXXXXX)
   mkdir -p $DIR/image/$newver/$bundle
   dd if=/dev/urandom of=$TMP bs=1 count=$newbytes
-  cat $DIR/image/$origver/$bundle/randomfile $TMP > $DIR/image/$newver/$bundle/randomfile
+  cat $DIR/image/$origver/$bundle/$name $TMP > $DIR/image/$newver/$bundle/$name
   rm $TMP
 }
 


### PR DESCRIPTION
For three different Clear Linux OS builds in the last few months, deltas
were created between files with type change L->F (symlink to file).
This was allowed to occur because there is no check if
file->peer->is_link in __create_delta().

Instead, remove the file->is_link check and simply ensure that the
from/to file types are both F (i.e. "regular file").