### PR TITLE
Skip subtraction when both files are deleted

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -117,6 +117,7 @@ dist_check_SCRIPTS = \
 	test/functional/no-delta/test.bats \
 	test/functional/pack/test.bats \
 	test/functional/state-file/test.bats \
+	test/functional/subtract-delete/test.bats \
 	test/functional/update/test.bats
 endif
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -582,6 +582,16 @@ void subtract_manifests(struct manifest *m1, struct manifest *m2)
 			list1 = g_list_next(list1);
 			list2 = g_list_next(list2);
 
+			/* When both files are marked deleted, skip
+			 * subtraction. Preserving the deleted entries in both
+			 * manifests is required for 'swupd update' to know
+			 * when to delete the file, because the m2 bundle may
+			 * be installed with or without the m1 bundle.
+			 */
+			if (file1->is_deleted && file2->is_deleted) {
+				continue;
+			}
+
 			if (file1->is_deleted == file2->is_deleted && file1->is_file == file2->is_file) {
 				m1->files = g_list_delete_link(m1->files, todel);
 				m1->count--;

--- a/test/functional/subtract-delete/test.bats
+++ b/test/functional/subtract-delete/test.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+# common functions
+load "../swupdlib"
+
+setup() {
+  clean_test_dir
+  init_test_dir
+
+  init_server_ini
+  set_latest_ver 0
+  init_groups_ini os-core test-bundle
+
+  # start with both bundles containing a file "foo"
+  set_os_release 10 os-core
+  track_bundle 10 os-core
+  track_bundle 10 test-bundle
+  gen_file_plain 10 os-core foo
+  gen_file_plain 10 test-bundle foo
+
+  # delete "foo" from os-core (the included bundle)
+  set_os_release 20 os-core
+  track_bundle 20 os-core
+  track_bundle 20 test-bundle
+  gen_file_plain 20 test-bundle foo
+
+  # delete "foo" from test-bundle
+  set_os_release 30 os-core
+  track_bundle 30 os-core
+  track_bundle 30 test-bundle
+
+  # make modification (add new file) to test-bundle
+  set_os_release 40 os-core
+  track_bundle 40 os-core
+  track_bundle 40 test-bundle
+  gen_file_plain 40 test-bundle foobar
+}
+
+@test "no subtraction for two deleted files" {
+  sudo $CREATE_UPDATE --osversion 10 --statedir $DIR --format 3
+  set_latest_ver 10
+  sudo $CREATE_UPDATE --osversion 20 --statedir $DIR --format 3
+  set_latest_ver 20
+  sudo $CREATE_UPDATE --osversion 30 --statedir $DIR --format 3
+  set_latest_ver 30
+  sudo $CREATE_UPDATE --osversion 40 --statedir $DIR --format 3
+  set_latest_ver 40
+
+  # If the file is absent in test-bundle, this means it was subtracted. If
+  # present, subtraction was not performed.
+  hash1=$(hash_for 40 test-bundle "/foo")
+  [ -n "$hash1" ]
+}
+
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
Subtracting files from manifests when both versions are marked deleted proves problematic for client updates, because the version at which the files were deleted will differ, and the client uses the versions to determine when it should delete files for an update.

As an example, consider a distro with 2 bundles, "A" and "B". Bundle B includes bundle A, which results in files in A being subtracted from B.  In this situation the following sequence of four changes result in a subtraction that prevents a client update from deleting a file.

1) In version 10, file /usr/foo is added to bundles A and B.
2) In version 20, /usr/foo is deleted from bundle A.
3) In version 30, /usr/foo is deleted from bundle B.
4) In version 40, bundle B is modified.

Due to arbitrary modifications to bundle B in step 4, /usr/foo is subtracted from bundle B, because it's also deleted in bundle A.  However, the file versions mismatch. So, an update from version 20 to 40 will result in /usr/foo not being deleted because the deleted entry from bundle A was not deleted in a version newer than 20.

This patch fixes the issue by ensuring that the deleted entry in bundle B remains intact for version 30. And the client update then works correctly: an update from 20 to 40 will properly delete /usr/foo, because 20 < 30 <= 40.