### PR TITLE
Prune debuginfo from manifests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -111,6 +111,7 @@ dist_check_SCRIPTS = \
 	test/functional/contentsize-across-versions-includes/test.bats \
 	test/functional/delete-no-version-bump/test.bats \
 	test/functional/file-name-blacklisted/test.bats \
+	test/functional/file-name-debuginfo/test.bats \
 	test/functional/format-no-decrement/test.bats \
 	test/functional/full-run-delta/test.bats \
 	test/functional/full-run/test.bats \

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -191,7 +191,7 @@ extern int match_manifests(struct manifest *m1, struct manifest *m2);
 extern void sort_manifest_by_version(struct manifest *manifest);
 extern bool manifest_includes(struct manifest *manifest, char *component);
 extern bool changed_includes(struct manifest *old, struct manifest *new);
-extern int prune_manifest(struct manifest *manifest);
+extern int prune_manifest(struct manifest *manifest, bool *pruned);
 extern int remove_old_deleted_files(struct manifest *m1, struct manifest *m2);
 extern void create_manifest_delta(int oldversion, int newversion, char *module);
 extern void create_manifest_deltas(struct manifest *manifest, GList *last_versions_list);
@@ -265,5 +265,6 @@ extern int system_argv_fd(char *const argv[], int newstdin, int newstdout, int n
 extern int system_argv_pipe(char *const argvp1[], int stdinp1, int stderrp1,
 			    char *const argvp2[], int stdoutp2, int stderrp2);
 extern int num_threads(float scaling);
+extern bool is_debuginfo(char *filename);
 
 #endif

--- a/src/create_update.c
+++ b/src/create_update.c
@@ -258,6 +258,7 @@ int main(int argc, char **argv)
 
 	int exit_status = EXIT_FAILURE;
 	int ret;
+	bool pruned;
 
 	char *file_path = NULL;
 
@@ -387,7 +388,7 @@ int main(int argc, char **argv)
 #endif
 		old_deleted = remove_old_deleted_files(old_core, new_core);
 		sort_manifest_by_version(new_core); /* sorts by filename */
-		newfiles = prune_manifest(new_core);
+		newfiles = prune_manifest(new_core, &pruned);
 		if (newfiles <= 0) {
 			LOG(NULL, "", "Core component has not changed (after pruning), exiting");
 			printf("Core component has not changed (after pruning), exiting\n");
@@ -509,8 +510,8 @@ int main(int argc, char **argv)
 			old_deleted = remove_old_deleted_files(oldm, newm);
 			sort_manifest_by_version(newm);
 			type_change_detection(newm);
-			newfiles = prune_manifest(newm);
-			if (newfiles > 0 || old_deleted > 0 || changed_includes(oldm, newm)) {
+			newfiles = prune_manifest(newm, &pruned);
+			if (newfiles > 0 || old_deleted > 0 || changed_includes(oldm, newm) || pruned) {
 				LOG(NULL, "", "%s component has changes (%d new, %d deleted), writing out new manifest", group, newfiles, old_deleted);
 				printf("%s component has changes (%d new, %d deleted), writing out new manifest\n", group, newfiles, old_deleted);
 				if (write_manifest(newm) != 0) {
@@ -549,7 +550,7 @@ int main(int argc, char **argv)
 	maximize_to_full(new_MoM, new_full);
 
 	sort_manifest_by_version(new_full);
-	prune_manifest(new_full);
+	prune_manifest(new_full, &pruned);
 	if (write_manifest(new_full) != 0) {
 		goto exit;
 	}

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -309,3 +309,9 @@ int num_threads(float scaling)
 
 	return result;
 }
+
+bool is_debuginfo(char *filename)
+{
+	return ((strncmp(filename, "/usr/lib/debug/", 15) == 0) ||
+		(strncmp(filename, "/usr/src/debug/", 15) == 0));
+}

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1032,12 +1032,13 @@ int remove_old_deleted_files(struct manifest *m1, struct manifest *m2)
  * Returns 0 when the pruned manifest no longer has new files.
  * Returns -1 on error.
  */
-int prune_manifest(struct manifest *manifest)
+int prune_manifest(struct manifest *manifest, bool *pruned)
 {
 	GList *list;
 	GList *next;
 	struct file *file;
 	int newfiles = 0;
+	*pruned = false;
 
 	/* prune some files */
 	list = g_list_first(manifest->files);
@@ -1055,6 +1056,10 @@ int prune_manifest(struct manifest *manifest)
 			// LOG(file, "Skipping deleted boot file in manifest write", "component %s", manifest->component);
 			manifest->files = g_list_delete_link(manifest->files, list);
 			manifest->count--;
+		} else if (is_debuginfo(file->filename)) {
+			manifest->files = g_list_delete_link(manifest->files, list);
+			manifest->count--;
+			*pruned = true;
 		}
 		list = next;
 	}

--- a/test/functional/file-name-debuginfo/test.bats
+++ b/test/functional/file-name-debuginfo/test.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+# common functions
+load "../swupdlib"
+
+setup() {
+  clean_test_dir
+  init_test_dir
+
+  init_server_ini
+  set_latest_ver 0
+  init_groups_ini os-core
+  init_groups_ini test-bundle
+
+  set_os_release 10 os-core
+  track_bundle 10 os-core
+  set_os_release 10 test-bundle
+  track_bundle 10 test-bundle
+
+  gen_file_plain 10 test-bundle "/usr/lib/debug/foo"
+  gen_file_plain 10 test-bundle "/usr/src/debug/bar"
+  gen_file_plain 10 test-bundle "/usr/bin/foobar"
+}
+
+@test "debuginfo files pruned" {
+  run sudo sh -c "$CREATE_UPDATE --osversion 10 --statedir $DIR --format 3"
+  # This should not be pruned
+  [[ 1 -eq $(grep '/usr/bin/foobar$' $DIR/www/10/Manifest.test-bundle | wc -l) ]]
+  [[ 1 -eq $(grep '/usr/lib/debug$' $DIR/www/10/Manifest.test-bundle | wc -l) ]]
+  [[ 1 -eq $(grep '/usr/src/debug$' $DIR/www/10/Manifest.test-bundle | wc -l) ]]
+  # These should be pruned
+  [[ 0 -eq $(grep '/usr/src/debug/bar$' $DIR/www/10/Manifest.test-bundle | wc -l) ]]
+  [[ 0 -eq $(grep '/usr/lib/debug/foo$' $DIR/www/10/Manifest.test-bundle | wc -l) ]]
+
+  echo "$output"
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
If debuginfo under /usr/lib/debug/ or /usr/src/debug/ are added to the
manifests mistakenly, prune those files. Make sure manifest is rewritten
when debuginfo files are pruned, even if no new files are added.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>