### PR TITLE
Prune debuginfo when configured to do so

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -267,5 +267,6 @@ extern int system_argv_fd(char *const argv[], int newstdin, int newstdout, int n
 extern int system_argv_pipe(char *const argvp1[], int stdinp1, int stderrp1,
 			    char *const argvp2[], int stdoutp2, int stderrp2);
 extern int num_threads(float scaling);
+extern bool file_is_debuginfo(const char *path);
 
 #endif

--- a/src/analyze_fs.c
+++ b/src/analyze_fs.c
@@ -305,32 +305,6 @@ static bool illegal_characters(const char *filename)
 	return false;
 }
 
-static bool illegal_path(const char *path)
-{
-	bool ret = false;
-	char *lib;
-	char *src;
-
-	lib = config_debuginfo_path("lib");
-	src = config_debuginfo_path("src");
-
-	// Don't allow debuginfo into the manifests
-	if (lib && (strncmp(path, lib, strlen(lib)) == 0)) {
-		ret = true;
-		goto out;
-	}
-
-	if (src && (strncmp(path, src, strlen(src)) == 0)) {
-		ret = true;
-		goto out;
-	}
-
-out:
-	free(lib);
-	free(src);
-	return ret;
-}
-
 static struct file *add_file(struct manifest *manifest,
 			     const char *entry_name,
 			     char *sub_filename,
@@ -340,7 +314,7 @@ static struct file *add_file(struct manifest *manifest,
 	GError *err = NULL;
 	struct file *file;
 
-	if (config_ban_debuginfo() && illegal_path(sub_filename)) {
+	if (config_ban_debuginfo() && file_is_debuginfo(sub_filename)) {
 		printf("WARNING: File %s is banned ...skipping.\n", sub_filename);
 		free(sub_filename);
 		free(fullname);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -309,3 +309,31 @@ int num_threads(float scaling)
 
 	return result;
 }
+
+/* This function is called when configuration specifies a ban on debuginfo files
+ * from manifests. Returns true if the passed file path matches the src or lib
+ * debuginfo configuration. */
+bool file_is_debuginfo(const char *path)
+{
+	bool ret = false;
+	char *lib;
+	char *src;
+
+	lib = config_debuginfo_path("lib");
+	src = config_debuginfo_path("src");
+
+	if (lib && (strncmp(path, lib, strlen(lib)) == 0)) {
+		ret = true;
+		goto out;
+	}
+
+	if (src && (strncmp(path, src, strlen(src)) == 0)) {
+		ret = true;
+		goto out;
+	}
+
+out:
+	free(lib);
+	free(src);
+	return ret;
+}

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1055,6 +1055,14 @@ int prune_manifest(struct manifest *manifest)
 			// LOG(file, "Skipping deleted boot file in manifest write", "component %s", manifest->component);
 			manifest->files = g_list_delete_link(manifest->files, list);
 			manifest->count--;
+		} else if (config_ban_debuginfo() && file_is_debuginfo(file->filename)) {
+			/* The configuration option to ban debuginfo from the manifests was
+			 * set in server.ini via the [Debuginfo][banned] option. Although
+			 * debuginfo additions are banned via analyze_fs, prune it here
+			 * to insure mistakenly included debuginfo from old versions is
+			 * removed from the manifests. */
+			manifest->files = g_list_delete_link(manifest->files, list);
+			manifest->count--;
 		}
 		list = next;
 	}


### PR DESCRIPTION
Fixes #71

Prune debuginfo from manifests when the [Debuginfo][pruned]
configuration is set to "true" in server.ini.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>