### PR TITLE
Remove timestamp field from manifests

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -751,7 +751,6 @@ static int write_manifest_plain(struct manifest *manifest)
 	fprintf(out, "version:\t%i\n", manifest->version);
 	fprintf(out, "previous:\t%i\n", manifest->prevversion);
 	fprintf(out, "filecount:\t%i\n", manifest->count);
-	fprintf(out, "timestamp:\t%i\n", (int)time(NULL));
 	compute_content_size(manifest);
 	fprintf(out, "contentsize:\t%llu\n", (long long unsigned int)manifest->contentsize);
 	includes = manifest->includes;


### PR DESCRIPTION
Fixes #79

The timestamp field is not used and is a barrier to reproducible builds.
Remove the timestamp field from the manifests.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>