### PR TITLE
Enable rename support for Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ install:
 # Ubuntu's default umask is 0002, but this break's swupd hash calculations.
 script:
         - sudo find test/functional -exec chmod g-w {} \;
-        - autoreconf --verbose --warnings=none --install --force && ./configure && make -j48 && sudo sh -c 'umask 0022 && make -j48 check'
+        - autoreconf --verbose --warnings=none --install --force && ./configure --enable-rename-detection && make -j48 && sudo sh -c 'umask 0022 && make -j48 check'
 after_failure: cat test-suite.log


### PR DESCRIPTION
Because renames are an opt-in feature (i.e. not enabled by default),
pass the required configure option for Travis builds, which enables the
rename tests.