### PR TITLE
Enable ghosted file generation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -116,6 +116,7 @@ dist_check_SCRIPTS = \
 	test/functional/full-run-delta/test.bats \
 	test/functional/full-run/test.bats \
 	test/functional/fullfiles/test.bats \
+	test/functional/ghosting/test.bats \
 	test/functional/include-version-bump/test.bats \
 	test/functional/includes-deduplicate/test.bats \
 	test/functional/no-delta/test.bats \

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -117,6 +117,10 @@ struct file {
 	unsigned int is_file : 1;
 	unsigned int is_link : 1;
 	unsigned int is_deleted : 1;
+	/* a ghosted file is treated as deleted so that it can be used as a rename,
+	 * but is not actually deleted in the client due to a 3rd-party program
+	 * cleaning it up. This happens with boot files managed by a boot manager */
+	unsigned int is_ghosted : 1;
 	unsigned int is_manifest : 1;
 
 	/* and these are modifiers */
@@ -194,7 +198,7 @@ extern void sort_manifest_by_version(struct manifest *manifest);
 extern bool manifest_includes(struct manifest *manifest, char *component);
 extern bool changed_includes(struct manifest *old, struct manifest *new);
 extern int prune_manifest(struct manifest *manifest);
-extern int remove_old_deleted_files(struct manifest *m1, struct manifest *m2);
+extern int remove_deprecated_files(struct manifest *m1, struct manifest *m2, bool (*compfunc)(struct file *, struct file *));
 extern void create_manifest_delta(int oldversion, int newversion, char *module);
 extern void create_manifest_deltas(struct manifest *manifest, GList *last_versions_list);
 extern void subtract_manifests_frontend(struct manifest *m1, struct manifest *m2);

--- a/src/analyze_fs.c
+++ b/src/analyze_fs.c
@@ -151,7 +151,13 @@ void populate_file_struct(struct file *file, char *filename)
 	ret = lstat(filename, &stat);
 	if (ret < 0) {
 		LOG(NULL, "stat error ", "%s: %s", filename, strerror(errno));
-		file->is_deleted = 1;
+		/* delete the file if it isn't found and isn't a boot file,
+		 * mark as ghosted if this is a boot file */
+		if (file->is_boot) {
+			file->is_ghosted = 1;
+		} else {
+			file->is_deleted = 1;
+		}
 		return;
 	}
 	file->stat.st_mode = stat.st_mode;

--- a/src/fullfiles.c
+++ b/src/fullfiles.c
@@ -298,6 +298,11 @@ static void submit_fullfile_tasks(GList *files)
 		file = item->data;
 		item = g_list_next(item);
 
+		/* do not push ghosted files */
+		if (file->is_ghosted) {
+			continue;
+		}
+
 		ret = g_thread_pool_push(threadpool, file, &err);
 		if (ret == FALSE) {
 			printf("GThread create_fullfile_task push error\n");

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -240,10 +240,22 @@ struct manifest *manifest_from_file(int version, char *component)
 			assert(0); /* unknown file type */
 		}
 
-		if (c[1] == 'd') {
+		switch (c[1]) {
+		case 'd':
+			/* file is deleted */
 			file->is_deleted = 1;
-		} else if (c[1] != '.') {
-			assert(0); /* unknown deleted status */
+			break;
+		case 'g':
+			/* file is ghosted */
+			file->is_ghosted = 1;
+			break;
+		case '.':
+			/* no flag at this index */
+			break;
+		default:
+			/* unknown deleted status */
+			LOG(NULL, "Invalid flag at index 1", "%s", c[1]);
+			assert(0);
 		}
 
 		if (c[2] == 'C') {
@@ -428,14 +440,19 @@ int match_manifests(struct manifest *m1, struct manifest *m2)
 			file3->is_config = file1->is_config;
 			file3->is_state = file1->is_state;
 			file3->is_boot = file1->is_boot;
+			/* ghost deleted boot files */
+			file3->is_ghosted = file1->is_boot && file1->is_deleted;
 
-			if (!file1->is_deleted) {
-				file3->last_change = m2->version;
-			} else {
-				file3->last_change = file1->last_change;
+			if (file3->is_ghosted || file1->is_deleted) {
+				/* if the new file is ghosted or the file was deleted, preserve
+				 * hash (all zeros if file1->is_deleted) and rename status */
 				file3->is_rename = file1->is_rename;
 				hash_assign(file1->hash, file3->hash);
 			}
+
+			/* for deleted files last_change remains the same.
+			 * otherwise last change is now */
+			file3->last_change = file1->is_deleted ? file1->last_change : m2->version;
 
 			file3->peer = file1;
 			file1->peer = file3;
@@ -656,6 +673,10 @@ char *file_type_to_string(struct file *file)
 
 	if (file->is_deleted) {
 		type[1] = 'd';
+	}
+
+	if (file->is_ghosted) {
+		type[1] = 'g';
 	}
 
 	if (file->is_config) {
@@ -968,7 +989,7 @@ bool changed_includes(struct manifest *old, struct manifest *new)
  *
  * Note: this function should be called after match_manifests().
  */
-int remove_old_deleted_files(struct manifest *m1, struct manifest *m2)
+int remove_deprecated_files(struct manifest *m1, struct manifest *m2, bool (*compfunc)(struct file *file1, struct file *file2))
 {
 	GList *list1, *list2;
 	struct file *file1, *file2;
@@ -1006,7 +1027,9 @@ int remove_old_deleted_files(struct manifest *m1, struct manifest *m2)
 
 		ret = strcmp(file1->filename, file2->filename);
 		if (ret == 0) {
-			if (file1->is_deleted && file2->is_deleted) {
+			/* use the comparison function passed in to determine if this file
+			 * should be removed */
+			if (compfunc(file1, file2)) {
 				GList *to_delete = list2;
 				list1 = g_list_next(list1);
 				list2 = g_list_next(list2);
@@ -1051,10 +1074,10 @@ int prune_manifest(struct manifest *manifest)
 			manifest->files = g_list_delete_link(manifest->files, list);
 			manifest->count--;
 		} else if (file->is_boot && file->is_deleted) {
-			// only expose the current best boot files, a client side entity can manage /boot's actual contents
-			// LOG(file, "Skipping deleted boot file in manifest write", "component %s", manifest->component);
-			manifest->files = g_list_delete_link(manifest->files, list);
-			manifest->count--;
+			/* mark boot files that are going away as ghosted, these will be
+			 * cleaned up with the next update */
+			file->is_deleted = 0;
+			file->is_ghosted = 1;
 		} else if (config_ban_debuginfo() && file_is_debuginfo(file->filename)) {
 			/* The configuration option to ban debuginfo from the manifests was
 			 * set in server.ini via the [Debuginfo][banned] option. Although

--- a/test/functional/ghosting/test.bats
+++ b/test/functional/ghosting/test.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+# common functions
+load "../swupdlib"
+
+setup() {
+  clean_test_dir
+  init_test_dir
+
+  init_server_ini
+  set_latest_ver 0
+  init_groups_ini os-core test-bundle
+
+  set_os_release 10 os-core
+  set_os_release 10 test-bundle
+  track_bundle 10 os-core
+  track_bundle 10 test-bundle
+
+  set_os_release 20 os-core
+  set_os_release 20 test-bundle
+  track_bundle 20 os-core
+  track_bundle 20 test-bundle
+
+  set_os_release 30 os-core
+  set_os_release 30 test-bundle
+  track_bundle 30 os-core
+  track_bundle 30 test-bundle
+
+  gen_file_plain_with_content 10 test-bundle usr/lib/kernel/bar testfile_contents
+  gen_file_plain_with_content 20 test-bundle usr/lib/kernel/baz new_testfile_contents
+  # make sure /usr/lib/kernel stays around
+  mkdir $DIR/image/30/test-bundle/usr/lib/kernel
+}
+
+@test "create updates while ghosting boot files before removing them" {
+  sudo $CREATE_UPDATE --osversion 10 --statedir $DIR --format 3
+  sudo $MAKE_FULLFILES --statedir $DIR 10
+
+  set_latest_ver 10
+
+  sudo $CREATE_UPDATE --osversion 20 --statedir $DIR --format 3
+  sudo $MAKE_FULLFILES --statedir $DIR 20
+
+  set_latest_ver 20
+
+  sudo $CREATE_UPDATE --osversion 30 --statedir $DIR --format 3
+  sudo $MAKE_FULLFILES --statedir $DIR 30
+  # version 10: add boot file to 10
+  [ 1 -eq $(grep 'F\.b\.	.*	10	/usr/lib/kernel/bar' $DIR/www/10/Manifest.full | wc -l) ]
+  # version 20: ghost boot file instead of deleting it when it doesn't exist
+  [ 1 -eq $(grep '\.gb\.	.*	20	/usr/lib/kernel/bar' $DIR/www/20/Manifest.full | wc -l) ]
+  # version 20: add a new boot file
+  [ 1 -eq $(grep 'F\.b\.	.*	20	/usr/lib/kernel/baz' $DIR/www/20/Manifest.full | wc -l) ]
+  # version 30: old ghosted file /usr/lib/kernel/bar cleaned up
+  [ 0 -eq $(grep '10	/usr/lib/kernel/bar' $DIR/www/30/Manifest.full | wc -l) ]
+  # version 30: boot file added in version 20 ghosted
+  [ 1 -eq $(grep '\.gb\.	.*	30	/usr/lib/kernel/baz' $DIR/www/30/Manifest.full | wc -l) ]
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
Ghost files that will be deleted by third-party software on the
client-side instead of marking them as deleted in the manifest. This
allows the client to treat these as deleted when doing rename detection.
Remove those ghosted files from the manifest in the next update.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

Fixes #94 