### PR TITLE
Fix ghosted-file deprecation

### DIFF
--- a/src/create_update.c
+++ b/src/create_update.c
@@ -336,7 +336,12 @@ int main(int argc, char **argv)
 	apply_heuristics(new_full);
 	match_manifests(old_full, new_full);
 
-	old_deleted = remove_deprecated_files(old_full, new_full, both_deleted);
+	if (old_full->format < new_full->format) {
+		old_deleted = remove_deprecated_files(old_full, new_full, both_deleted);
+	} else {
+		old_deleted = 0;
+	}
+
 	if (old_deleted > 0) {
 		LOG(NULL, "", "Old deleted files (%d) removed from full manifest", old_deleted);
 		printf("Old deleted files (%d) removed from full manifest\n", old_deleted);
@@ -402,7 +407,12 @@ int main(int argc, char **argv)
 		/* Detect renamed files specifically for os-core */
 		rename_detection(new_core);
 #endif
-		old_deleted = remove_deprecated_files(old_core, new_core, both_deleted);
+		if (old_core->format < new_core->format) {
+			old_deleted = remove_deprecated_files(old_core, new_core, both_deleted);
+		} else {
+			old_deleted = 0;
+		}
+
 		old_ghosted = remove_deprecated_files(old_core, new_core, both_ghosted);
 		sort_manifest_by_version(new_core); /* sorts by filename */
 		/* clean up orphaned renames by marking them as deleted */
@@ -526,7 +536,12 @@ int main(int argc, char **argv)
 			rename_detection(newm);
 #endif
 			/* Step 6b: otherwise, write out the manifest */
-			old_deleted = remove_deprecated_files(oldm, newm, both_deleted);
+			if (oldm->format < newm->format) {
+				old_deleted = remove_deprecated_files(oldm, newm, both_deleted);
+			} else {
+				old_deleted = 0;
+			}
+
 			old_ghosted = remove_deprecated_files(oldm, newm, both_ghosted);
 			sort_manifest_by_version(newm);
 			type_change_detection(newm);

--- a/test/functional/ghosting/test.bats
+++ b/test/functional/ghosting/test.bats
@@ -52,7 +52,7 @@ setup() {
   # version 20: add a new boot file
   [ 1 -eq $(grep 'F\.b\.	.*	20	/usr/lib/kernel/baz' $DIR/www/20/Manifest.full | wc -l) ]
   # version 30: old ghosted file /usr/lib/kernel/bar cleaned up
-  [ 0 -eq $(grep '10	/usr/lib/kernel/bar' $DIR/www/30/Manifest.full | wc -l) ]
+  [ 0 -eq $(grep '/usr/lib/kernel/bar' $DIR/www/30/Manifest.full | wc -l) ]
   # version 30: boot file added in version 20 ghosted
   [ 1 -eq $(grep '\.gb\.	.*	30	/usr/lib/kernel/baz' $DIR/www/30/Manifest.full | wc -l) ]
 }


### PR DESCRIPTION
Ghosted files were only being deprecated over format bumps. Move the
format-bump-check logic out to the calling function to allow ghosted
files to be removed on every build. Also assign the is_ghosted flag when
adding "deleted" files from the old manifest so that the file will
actually be removed.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>