### PR TITLE
test: fix some typos in checkrenamed()

### DIFF
--- a/test/functional/renames/test.bats
+++ b/test/functional/renames/test.bats
@@ -47,7 +47,7 @@ gendataCs() {
 }
 
 checkrenamed(){
-    local flags sh1 ver name fromsha1="bad" tosha1
+    local flags sha1 ver name fromsha1="bad" tosha1
     # Check that $1 is renamed to $2
     exec 9< $DIR/www/20/Manifest.test-bundle
     # skip the header
@@ -58,11 +58,11 @@ checkrenamed(){
     while read -r -u9 flags sha1 ver name
     do
 	case "$flags" in
-	    (?"dr"?) [ "$name" = "$1" ] && fromsha1=$sha1 ;;
-	    (?".r"?) [ "$name" = "$2" ] && tosha1=$sha1 ;;
+	    (?"d.r") [ "$name" = "$1" ] && fromsha1=$sha1 ;;
+	    (?"..r") [ "$name" = "$2" ] && tosha1=$sha1 ;;
 	esac
     done
-    if [ "$fromsh1" = "$tosha1" ] ; then return 0 ; else return 1 ; fi
+    if [ "$fromsha1" = "$tosha1" ] ; then return 0 ; else return 1 ; fi
 }
 
 # Guts of doing an update

--- a/test/functional/renames/test.bats
+++ b/test/functional/renames/test.bats
@@ -87,7 +87,7 @@ do_an_update() {
   gendataA 10 foo
   gendataA 20 bar
   do_an_update
-  checkrenamed foo bar
+  checkrenamed /foo /bar
 }
 
 @test "ignore rename detection for small files" {
@@ -142,8 +142,8 @@ do_an_update() {
   gendataA 20 bar
   gendataA 20 baz  
   do_an_update
-  checkrenamed foo bar
-  checkrenamed foz baz
+  checkrenamed /foo /bar
+  checkrenamed /foz /baz
 }
 
 @test "rename two files to two, one slightly different" {
@@ -153,8 +153,8 @@ do_an_update() {
   gendataB 20 baz  
   do_an_update
   # we don't actually know how the client we do this rename, but don't care
-  checkrenamed foo bar
-  checkrenamed foz baz
+  checkrenamed /foo /bar
+  checkrenamed /foz /baz
 }
 
 @test "rename two files to two, each pair slightly different" {
@@ -163,8 +163,8 @@ do_an_update() {
   gendataA 20 bar
   gendataB 20 baz
   do_an_update
-  checkrenamed foo bar
-  checkrenamed foz baz
+  checkrenamed /foo /bar
+  checkrenamed /foz /baz
 }
 
 @test "rename two files to two, one very different" {
@@ -183,9 +183,9 @@ do_an_update() {
   gendataA 20 bar
   gendataCs 20 baz  
   do_an_update
-  run checkrenamed foo bar
+  run checkrenamed /foo /bar
   if [ $status -eq 1 ] ; then
-    checkrenamed foz bar
+    checkrenamed /foz /bar
   fi
 }
 


### PR DESCRIPTION
Due to these typos being present, several tests were passing that should not have been.

This is not merge-ready yet; I'm opening it to track the resultant test failures and work to fix them.